### PR TITLE
DebitInvoiceType extends InvoiceType - Typo Fix

### DIFF
--- a/src/content/book/05-states.md
+++ b/src/content/book/05-states.md
@@ -286,7 +286,7 @@ class CreditInvoiceType extends InvoiceType
 ```
 
 ```php
-class DebitInvoiceType extends InvoiceState
+class DebitInvoiceType extends InvoiceType
 {
     public function mustBePaid(): bool
     {


### PR DESCRIPTION
DebitInvoiceType extends InvoiceType instead of InvoiceState