### PR TITLE
Formatting of Concatenation precedence example

### DIFF
--- a/src/content/blog/2019-01-01-new-in-php-74.md
+++ b/src/content/blog/2019-01-01-new-in-php-74.md
@@ -243,7 +243,7 @@ echo ("sum: " . $a) + $b;
 PHP 8 will make it so that it's interpreted like this:
 
 ```php
-echo "sum :" . ($a + $b);
+echo "sum: " . ($a + $b);
 ```
 
 PHP 7.4 adds a deprecation warning when encountering an unparenthesized expression containing a `.` before a `+` or `-` sign.


### PR DESCRIPTION
Just moves the space to after the colon instead of before in the PHP 8 example.