### PR TITLE
Add invalid stream resource TypeError

### DIFF
--- a/src/content/blog/2020-01-16-new-in-php-8.md
+++ b/src/content/blog/2020-01-16-new-in-php-8.md
@@ -228,6 +228,7 @@ Lots of errors that previously only triggered warnings or notices, have been con
 - String offset cast occurred: warning instead of notice
 - Uninitialized string offset: %d: warning instead of notice
 - Cannot assign an empty string to a string offset: `Error` exception instead of warning
+- Supplied resource is not a valid stream resource: `TypeError` exception instead of warning
 
 ### Default error reporting level
 


### PR DESCRIPTION
Hey there :vulcan_salute:,

first of all: thanks for your blog :+1: 

I would like to add this change in behavior:
```php
<?php

$fp = tmpfile();
fclose($fp);
fread($fp,1);

// PHP <= 7.4
// Warning: fread(): supplied resource is not a valid stream resource
//
// PHP 8
// Fatal error: Uncaught TypeError: fread(): supplied resource is not a valid stream resource
```
