### PR TITLE
📝 Update 2020-01-16-new-in-php-8.md

### DIFF
--- a/src/content/blog/2020-01-16-new-in-php-8.md
+++ b/src/content/blog/2020-01-16-new-in-php-8.md
@@ -461,7 +461,7 @@ class UsesTrait
 
 ### Object implementation of `<hljs prop>token_get_all</hljs>()` <small>[RFC](*https://wiki.php.net/rfc/token_as_object)</small>
 
-The `<hljs prop>token_get_all</hljs>()` function returns an array of values. This RFC adds a `<hljs type>PhpToken</hljs>` class with a `<hljs type>PhpToken</hljs>::<hljs prop>getAll</hljs>()` method. This implementation works with objects instead of plain values. It consumes less memory and is easier to read.
+The `<hljs prop>token_get_all</hljs>()` function returns an array of values. This RFC adds a `<hljs type>PhpToken</hljs>` class with a `<hljs type>PhpToken</hljs>::<hljs prop>tokenize</hljs>()` method. This implementation works with objects instead of plain values. It consumes less memory and is easier to read.
 
 ---
 


### PR DESCRIPTION
Hello,

In RC4 the `PhpToken::getAll()` method has been renamed to `PhpToken::tokenize()`:

> Note: PhpToken::getAll() has been renamed to PhpToken::tokenize() prior to the PHP 8.0 release. The RFC text still refers to PhpToken::getAll().

This PR updates the content of the [What's new in PHP 8](https://stitcher.io/blog/new-in-php-8) blog.