### PR TITLE
Fix "I for one"

### DIFF
--- a/src/content/blog/2021-01-29-new-in-php-81.md
+++ b/src/content/blog/2021-01-29-new-in-php-81.md
@@ -57,7 +57,7 @@ You can now use `0o` and `0O` to denote octal numbers. The previous notation by 
 
 Even though there hasn't been a vote yet, this proposal to add enums has been received with enthusiasm. If you're unsure about the value they add, you can read about them [here](*/blog/php-enums).
 
-Adding enums would be a significant improvement in PHP, so I'm for one am very much looking forward to seeing this RFC further evolve. To give you a quick preview of what they would look like, here's a code sample:
+Adding enums would be a significant improvement in PHP, so I for one am very much looking forward to seeing this RFC further evolve. To give you a quick preview of what they would look like, here's a code sample:
 
 ```php
 <hljs keyword>enum</hljs> <hljs type>Status</hljs> {


### PR DESCRIPTION
Just removing the errant apostrophe-m. Because you "are for one are" not :wink: 

I would have added commas around the "for one" too (ie. "I, for one, would have added ...") but thought that made the paragraph overall too comma heavy. But might be something to consider if you ever want to rewrite the sentence.