### PR TITLE
Update 2021-04-15-php-in-2021.md

### DIFF
--- a/src/content/blog/2021-04-15-php-in-2021.md
+++ b/src/content/blog/2021-04-15-php-in-2021.md
@@ -18,7 +18,7 @@ Year after year, the core team succeeds in bringing a new stable release to the 
 
 ## PHP's type system
 
-There's actually some very exiting news when it comes to types: [enums](/blog/php-enums) will be added in [PHP 8.1](/blog/new-in-php-81). On top of that we've also seen some of the maintainers of static analysis tools contributing to PHP's source code by landing their first RFC. It that adds the [`<hljs type>never</hljs>`](/blog/new-in-php-81#new-never-type-rfc) type.
+There's actually some very exciting news when it comes to types: [enums](/blog/php-enums) will be added in [PHP 8.1](/blog/new-in-php-81). On top of that we've also seen some of the maintainers of static analysis tools contributing to PHP's source code by landing their first RFC. It that adds the [`<hljs type>never</hljs>`](/blog/new-in-php-81#new-never-type-rfc) type.
 
 Speaking of static analysis tools, PhpStorm has [added](*https://blog.jetbrains.com/phpstorm/2020/07/phpstan-and-psalm-support-coming-to-phpstorm/) built-in support for [Psalm](*https://psalm.dev/) and [PhpStan](*https://github.com/phpstan/phpstan), which is a great step towards broader adaptation.
 


### PR DESCRIPTION
fix: curious typo ("exiting news" vs "exciting news")