### PR TITLE
Update 2017-11-11-shorthand-comparisons-in-php.md

### DIFF
--- a/src/content/blog/2017-11-11-shorthand-comparisons-in-php.md
+++ b/src/content/blog/2017-11-11-shorthand-comparisons-in-php.md
@@ -154,10 +154,10 @@ It will either trigger an error or return a boolean, instead of the real lefthan
 $output = isset($input['key']) ?: 'fallback' 
 
 // The following will trigger an 'undefined index' notice 
-// when $output is no array or has no 'key'.
+// when $input is no array or has no 'key'.
 //
 // It will trigger an 'undefined variable' notice 
-// when $output doesn't exist.
+// when $input doesn't exist.
 $output = $input['key'] ?: 'fallback';
 ```
 


### PR DESCRIPTION
Fix a comment in a code example where output and input are messed up.

Excellent article.

Thanks for the clarifications.