### PR TITLE
Fix type for in _New in initializers_ example

### DIFF
--- a/src/content/blog/2021-11-06-php-81-in-8-code-blocks.md
+++ b/src/content/blog/2021-11-06-php-81-in-8-code-blocks.md
@@ -42,7 +42,7 @@ class PostData
 class PostStateMachine
 {
     public function __construct(
-        <hljs keyword>private</hljs> <hljs type>string</hljs> <hljs prop>$state</hljs> = <hljs keyword>new</hljs> <hljs type>Draft</hljs>(),
+        <hljs keyword>private</hljs> <hljs type>State</hljs> <hljs prop>$state</hljs> = <hljs keyword>new</hljs> <hljs type>Draft</hljs>(),
     ) {
     }
 }


### PR DESCRIPTION
Unless I missed something extra magical about typecasting in promoted properties I think this was a typo?