### PR TITLE
Set type as an object, rather than string

### DIFF
--- a/src/content/blog/2021-11-06-php-81-in-8-code-blocks.md
+++ b/src/content/blog/2021-11-06-php-81-in-8-code-blocks.md
@@ -42,7 +42,7 @@ class PostData
 class PostStateMachine
 {
     public function __construct(
-        <hljs keyword>private</hljs> <hljs type>string</hljs> <hljs prop>$state</hljs> = <hljs keyword>new</hljs> <hljs type>Draft</hljs>(),
+        <hljs keyword>private</hljs> <hljs type>State</hljs> <hljs prop>$state</hljs> = <hljs keyword>new</hljs> <hljs type>InitialState</hljs>(),
     ) {
     }
 }


### PR DESCRIPTION
Set type as an object, rather than string for new-in-initializers example. 

It seemed confusing at first, with type set to `string` and default as an object. I've suggested an update similar to the actual initializers page example.