### PR TITLE
typo correction

### DIFF
--- a/src/content/blog/2021-01-29-new-in-php-81.md
+++ b/src/content/blog/2021-01-29-new-in-php-81.md
@@ -352,7 +352,7 @@ Just like the fileinfo change, IMAP functions like `<hljs prop>imap_body</hljs>`
 
 ### Deprecate passing null to non-nullable arguments of internal functions <small>[RFC](*https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg)</small>
 
-This change is simple: internal functions currently accept `null` for arguments that are non-nullable, this RFC deprecates that behaviour. For example, this is currently possible:
+This change is simple: internal functions currently accept `null` for arguments that are non-nullable, this RFC deprecates that behaviour. For example, this is currently not possible:
 
 ```php
 <hljs prop>str_contains</hljs>("string", <hljs striped>null</hljs>);


### PR DESCRIPTION
Typo in following section:

Deprecate passing null to non-nullable arguments of internal functions