### PR TITLE
Update 2020-01-16-new-in-php-8.md

### DIFF
--- a/src/content/blog/2020-01-16-new-in-php-8.md
+++ b/src/content/blog/2020-01-16-new-in-php-8.md
@@ -495,7 +495,7 @@ User-defined functions in PHP will already throw `<hljs type>TypeError</hljs>`, 
 
 Lots of errors that previously only triggered warnings or notices, have been converted to proper errors. The following warnings were changed.
 
-- Undefined variable: `<hljs type>Error</hljs>` exception instead of notice
+- Undefined variable: warning instead of notice
 - Undefined array index: warning instead of notice
 - Division by zero: `<hljs type>DivisionByZeroError</hljs>` exception instead of warning
 - Attempt to increment/decrement property '%s' of non-object: `<hljs type>Error</hljs>` exception instead of warning


### PR DESCRIPTION
"A number of notices have been converted into warnings: Attempting to read an undefined variable."
See: https://www.php.net/manual/en/migration80.incompatible.php