### PR TITLE
Changed the link to the PHP 8.1 upgrade guide

### DIFF
--- a/src/content/blog/2021-01-29-new-in-php-81.md
+++ b/src/content/blog/2021-01-29-new-in-php-81.md
@@ -383,7 +383,7 @@ $array = false;
 
 ### Other small changes
 
-With every release, there's a bunch of very minor changes to the language. All of them are listed in the [UPGRADING](*https://github.com/php/php-src/blob/master/UPGRADING) guide on GitHub and the [small deprecations RFC](https://wiki.php.net/rfc/deprecations_php_8_1), make sure to check it out if you want to know every little detail.
+With every release, there's a bunch of very minor changes to the language. All of them are listed in the [UPGRADING](*https://github.com/php/php-src/blob/PHP-8.1.0/UPGRADING) guide on GitHub and the [small deprecations RFC](https://wiki.php.net/rfc/deprecations_php_8_1), make sure to check it out if you want to know every little detail.
 
 Here's a summary of the most significant changes:
 


### PR DESCRIPTION
Since the master branch now refers to the 8.2 upgrade guide.