### PR TITLE
Update 2022-01-15-php-in-2022.md

### DIFF
--- a/src/content/blog/2022-01-15-php-in-2022.md
+++ b/src/content/blog/2022-01-15-php-in-2022.md
@@ -59,7 +59,7 @@ Which, combined with PHP 8.0's [promoted properties](/blog/constructor-promotion
 
 
 ```php
-class BlogData
+class PostData
 {
     /** @var <hljs type>string</hljs> */
     private <hljs prop>$title</hljs>;


### PR DESCRIPTION
Changed BlogData to PostData to keep the names consistent of the same model in the different PHP versions.