### PR TITLE
SensitiveParameter from global namespace

### DIFF
--- a/src/content/blog/2022-04-22-new-in-php-82.md
+++ b/src/content/blog/2022-04-22-new-in-php-82.md
@@ -94,7 +94,7 @@ Here's an example from the RFC:
 ```php
 function test(
     $foo,
-    #[<hljs type>SensitiveParameter</hljs>] $bar,
+    #[<hljs type>\SensitiveParameter</hljs>] $bar,
     $baz
 ) {
     throw new <hljs type>Exception</hljs>('Error');


### PR DESCRIPTION
Load `\SensitiveParameter` from global namespace to ease copy/pasta. As code is often in a namespace.