### PR TITLE
Fix typos

### DIFF
--- a/src/content/blog/2022-04-22-new-in-php-82.md
+++ b/src/content/blog/2022-04-22-new-in-php-82.md
@@ -166,7 +166,7 @@ trait <hljs type>Foo</hljs>
 }
 ```
 
-You won't be able to access the constant via the trait's name, neither from outside the trait, nor from inside it.
+You won't be able to access the constant via the trait's name, either from outside the trait, or from inside it.
 
 ```php
 trait <hljs type>Foo</hljs> 
@@ -317,7 +317,7 @@ From the [UPGRADING](https://github.com/php/php-src/blob/master/UPGRADING#L28-L3
 
 > The `ODBC` extension now escapes the username and password for the case when
 both a connection string and username/password are passed, and the string
-must be appended to
+must be appended to.
 
 The same applies to `PDO_ODBC`.
 


### PR DESCRIPTION
I hope these don’t seem too nitpicking…

* The first change is a double negative: “either… or” should always be used after a negative clause. 
* The `.` is for clarity: I thought the quote got clipped because of the sentence structure, but the source confirmed that was the end of the sentence! Including the punctuation should help that be clear. 