### PR TITLE
docs(php8.2): Deprecate dynamic properties

### DIFF
--- a/src/content/blog/2022-04-22-new-in-php-82.md
+++ b/src/content/blog/2022-04-22-new-in-php-82.md
@@ -57,12 +57,12 @@ I'd say this is a change for the better, but it will hurt a little bit. Dynamic 
 ```php
 class Post
 {
-    public <hljs type>string</hljs> <hljs prop>$title</hljs>;
+    public <hljs type>int</hljs> <hljs prop>$age</hljs>;
 }
 
 // …
 
-$post-><hljs striped>name</hljs> = 'Name';
+$post-><hljs striped>age</hljs> = 'Name';
 ```
 
 Keep in mind that classes implementing `<hljs prop>__get</hljs>` and `<hljs prop>__set</hljs>` will still work as intended:


### PR DESCRIPTION
Types must be different to throw an exception