### PR TITLE
Fix AllowDynamicProperties attribute

### DIFF
--- a/src/content/blog/2022-08-08-deprecated-dynamic-properties-in-php-82.md
+++ b/src/content/blog/2022-08-08-deprecated-dynamic-properties-in-php-82.md
@@ -87,7 +87,7 @@ If you _really_ want to use dynamic properties without implementing `<hljs prop>
 The PHP core team has provided a built-in [attribute](/blog/attributes-in-php-8) called `<hljs type>AllowDynamicProperties</hljs>`.As its name suggests, it allows dynamic properties on classes, without having to rely on sketchy extends:
 
 ```php
-#[<hljs type>AllowDynamicProperties</hljs>]
+#[<hljs type>\AllowDynamicProperties</hljs>]
 class Post
 {
 }


### PR DESCRIPTION
I've been digging into `AllowDynamicProperties` attribute to make Livewire's core compatible with 8.2 and was running into issues with Orchestra/TestBench, see here for details https://twitter.com/_joshhanley/status/1601053855646875648

Once Crynobone helped me fix that issue, I started testing out the `AllowDynamicProperties` attribute, but couldn't get it working to start with.

Turns out, it needs the backslash before the attribute name to work correctly `#[\AllowDynamicProperties]` when using on a class that is namespaced.

This makes sense to me now in hindsight but it tripped me up.

As such, this PR updates your article to add the backslash in as that would be the general use-case.

I've also found it's done the same way (without the backslash) in the PHP documentation example here https://www.php.net/manual/en/class.allow-dynamic-properties.php.

I've submitted a user contributed note to the PHP documentation.

So up to you whether to merge or not (or maybe we can make a note instead?). And whether you want to put a namespace before the example class or not.

Hope this helps!