### PR TITLE
Fix typo in cta_mail.twig

### DIFF
--- a/resources/view/_partials/cta_mail.twig
+++ b/resources/view/_partials/cta_mail.twig
@@ -1,5 +1,5 @@
 <div class="author">
-    Noticed a tpyo? You can <a href="https://github.com/brendt/stitcher.io" target="_blank" rel="noopener noreferrer">submit a PR</a> to fix it.
+    Noticed a typo? You can <a href="https://github.com/brendt/stitcher.io" target="_blank" rel="noopener noreferrer">submit a PR</a> to fix it.
 
     If you want to stay up to date about what's happening on this blog, you can follow me
     on <a href="https://mobile.twitter.com/brendt_gd" target="_blank" rel="noopener noreferrer">Twitter</a> or subscribe to my newsletter:


### PR DESCRIPTION
Hi @brendt ,

I really enjoy your blog :) `Don't be clever` sounds like the story of my early web developer career days :) 

I have noticed literally the same typos as @oddvalue fixed in his PR -> https://github.com/brendt/stitcher.io/pull/236, but he was 20 minutes quicker :)
Anyway, found one more in `cta_mail.twig`.

Cheers,
bl4de
