### PR TITLE
Fix fatal error in example, 2023-06-21-override-in-php-83.md

### DIFF
--- a/src/content/blog/2023-06-21-override-in-php-83.md
+++ b/src/content/blog/2023-06-21-override-in-php-83.md
@@ -16,7 +16,7 @@ abstract class Parent
 final class Child extends Parent
 {
     #[<hljs type>Override</hljs>]
-    public function methodWithDefaultImplementation(): void
+    public function methodWithDefaultImplementation(): int
     {
         return 2; // The overridden method
     }


### PR DESCRIPTION
The example would throw a fatal error due to the wrong return type being used in the example override method.