### PR TITLE
Update 2023-03-17-new-in-php-83.md

### DIFF
--- a/src/content/blog/2023-03-17-new-in-php-83.md
+++ b/src/content/blog/2023-03-17-new-in-php-83.md
@@ -64,7 +64,7 @@ abstract class Parent
 final class Child extends Parent
 {
     #[<hljs type>Override</hljs>]
-    public function methodWithDefaultImplementation(): void
+    public function methodWithDefaultImplementation(): int
     {
         return 2; // The overridden method
     }


### PR DESCRIPTION
Fix return type in example, which would throw fatal

This applies the same fix to the new in php 8.3 post as https://github.com/brendt/stitcher.io/commit/fe5e48a69a60534583056f2ac007c9522e3b631d does to the override in php 8.3 post