### PR TITLE
Fix typo in type "never" at "New in PHP 8.1" post

### DIFF
--- a/src/content/blog/2021-01-29-new-in-php-81.md
+++ b/src/content/blog/2021-01-29-new-in-php-81.md
@@ -161,7 +161,7 @@ If you like this style of programming, you'd need to create a new interface `<hl
 
 ### New `<hljs type>never</hljs>` type <small>[RFC](*https://wiki.php.net/rfc/noreturn_type)</small>
 
-The `<hljs type>never</hljs>` type can be used to indicated that a function will actually stop the program flow. This can be done either by throwing an exception, calling `<hljs keyword>exit</hljs>` or other similar functions.
+The `<hljs type>never</hljs>` type can be used to indicate that a function will actually stop the program flow. This can be done either by throwing an exception, calling `<hljs keyword>exit</hljs>` or other similar functions.
 
 ```php
 function dd(<hljs type>mixed</hljs> $input): never


### PR DESCRIPTION
Fixing a small typo. `indicated` -> `indicate`