### PR TITLE
Fix mistake in namespace name and code example

### DIFF
--- a/src/content/blog/2024-05-15-new-in-php-84.md
+++ b/src/content/blog/2024-05-15-new-in-php-84.md
@@ -101,12 +101,10 @@ function save(?Book $book = null) {}
 
 ### New DOM HTML5 support <small>[RFC](*https://wiki.php.net/rfc/domdocument_html5_parser)</small>
 
-PHP 8.4 adds a `{php}\DOM\HTMLDocument` class which is able to parse HTML5 code properly. The old `{php}\DOMDocument` class is still available for backwards compatibility.
+PHP 8.4 adds a `{php}\Dom\HTMLDocument` class which is able to parse HTML5 code properly. The old `{php}\DOMDocument` class is still available for backwards compatibility.
 
 ```php
-$doc = new \DOM\HTMLDocument();
-
-$doc->loadHTML($contents);
+$doc = \Dom\HTMLDocument::createFromString($contents);
 ```
 
 ---


### PR DESCRIPTION
The new Dom class uses named constructors, and the namespace name was amended by https://wiki.php.net/rfc/class-naming-acronyms