### PR TITLE
Add a Testo suite next to a restored (and tuned) PHPUnit suite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,33 @@ DISCOVERY_CACHE=false
 # Overwrite default log paths (null = default)
 DEBUG_LOG_PATH=null
 SERVER_LOG_PATH=null
+
+# Database connection used by the application.
+DATABASE_HOST=localhost
+DATABASE_PORT=3306
+DATABASE_USERNAME=root
+DATABASE_PASSWORD=
+DATABASE_DATABASE=stitcher
+
+# Database connection used by the test suites. The runners derive a per-worker
+# database from this name by appending `-0`, `-1`, ... — create those upfront,
+# they are not created for you.
+TEST_DATABASE_HOST=localhost
+TEST_DATABASE_PORT=3306
+TEST_DATABASE_USERNAME=root
+TEST_DATABASE_PASSWORD=
+TEST_DATABASE_DATABASE=stitcher-testing
+
+# Redis used by the test suites.
+TEST_REDIS_HOST=127.0.0.1
+TEST_REDIS_PORT=6379
+
+# OAuth credentials. These are required to boot the application, even locally:
+# the OAuth configs are typed as non-nullable strings, and an empty value is
+# read back as null. Use any placeholder if you don't need the provider.
+DISCORD_CLIENT_ID=placeholder
+DISCORD_CLIENT_SECRET=placeholder
+GITHUB_CLIENT_ID=placeholder
+GITHUB_CLIENT_SECRET=placeholder
+GOOGLE_CLIENT_ID=placeholder
+GOOGLE_CLIENT_SECRET=placeholder

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
-.tempest
+/.*/
+!/.github/
 node_modules/
 vendor/
 /public/main.css
 /package-lock.json
 /.php-cs-fixer.cache
 .env
-.idea
 .phpunit.result.cache
 log/
 *.local.config.php
@@ -25,7 +25,6 @@ public/**/index.html
 last-id
 app/Mail/input
 app/Mail/output.sql
-/.claude/
 /app/Php/Docs/md/
 /app/Php/Docs/xml/
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,11 @@
         "symfony/var-dumper": "^7.3.3",
         "carthage-software/mago": "^1.40",
         "rector/rector": "^2.3",
-        "tempest/testing": "dev-main"
+        "tempest/testing": "dev-main",
+        "testo/testo": "*",
+        "llm/skills": "^1.9",
+        "phpunit/phpunit": "^13.2",
+        "testo/bridge-rector": "^0.2.0"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +30,9 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "tests/"
+            "Tests\\": "tests/",
+            "Tests\\PHPUnit\\": "phpunit/",
+            "Tests\\Testo\\": "testo/"
         }
     },
     "scripts": {
@@ -43,6 +49,8 @@
         "lint": "vendor/bin/mago lint --reporting-format=rich && vendor/bin/mago lint --fix --format-after-fix",
         "analyse": "vendor/bin/mago analyse --baseline=mago-baseline.toml",
         "test": "tempest test",
+        "testo": "testo run",
+        "phpunit": "phpunit",
         "qa": [
             "composer fmt",
             "composer analyse",
@@ -60,7 +68,8 @@
         "allow-plugins": {
             "php-http/discovery": true,
             "carthage-software/mago": true,
-            "codewithkyrian/platform-package-installer": true
+            "codewithkyrian/platform-package-installer": true,
+            "llm/skills": true
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "adeefda19233260661ddf89bf65b371d",
+    "content-hash": "1d21f6842b2fadcc63a7b02f416c7f77",
     "packages": [
         {
             "name": "chrome-php/chrome",
@@ -6588,6 +6588,2080 @@
             "time": "2026-07-18T22:50:18+00:00"
         },
         {
+            "name": "internal/destroy",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-internal/destroy.git",
+                "reference": "93068c4f7da218034f5373e31407f564b74b4a06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-internal/destroy/zipball/93068c4f7da218034f5373e31407f564b74b4a06",
+                "reference": "93068c4f7da218034f5373e31407f564b74b4a06",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "buggregator/trap": "^1.10",
+                "phpunit/phpunit": "^10.5",
+                "spiral/code-style": "^2.2.2",
+                "ta-tikoma/phpunit-architecture-test": "^0.8.4",
+                "vimeo/psalm": "^6.10"
+            },
+            "suggest": {
+                "ext-simplexml": "to support XML configs parsing"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Internal\\Destroy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "keywords": [
+                "download binaries",
+                "memory"
+            ],
+            "support": {
+                "issues": "https://github.com/php-internal/destroy/issues",
+                "source": "https://github.com/php-internal/destroy/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://patreon.com/roxblnfk",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-09-08T14:29:16+00:00"
+        },
+        {
+            "name": "internal/path",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-internal/path.git",
+                "reference": "ec0ddb060a204793f1ddfb5219bb024a754df0e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-internal/path/zipball/ec0ddb060a204793f1ddfb5219bb024a754df0e0",
+                "reference": "ec0ddb060a204793f1ddfb5219bb024a754df0e0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "buggregator/trap": "^1.15",
+                "roxblnfk/unpoly": "^1.8.1",
+                "spiral/code-style": "^2.3.1",
+                "testo/testo": "^1.0@dev",
+                "vimeo/psalm": "^6.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Internal\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Type-safe, immutable file path library with cross-platform support and automatic normalization.",
+            "keywords": [
+                "cross-platform",
+                "file",
+                "filepath",
+                "filesystem",
+                "helper",
+                "path",
+                "unix",
+                "windows"
+            ],
+            "support": {
+                "issues": "https://github.com/php-internal/path/issues",
+                "source": "https://github.com/php-internal/path/tree/1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2025-12-03T11:32:09+00:00"
+        },
+        {
+            "name": "llm/skills",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/roxblnfk/skills.git",
+                "reference": "a3d0114a2d3db957071560e26fdb2c11e1b9103f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/roxblnfk/skills/zipball/a3d0114a2d3db957071560e26fdb2c11e1b9103f",
+                "reference": "a3d0114a2d3db957071560e26fdb2c11e1b9103f",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "internal/path": "^1.2",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "buggregator/trap": "^1.10",
+                "composer/composer": "^2.9.0",
+                "infection/infection": "dev-testo-bridge-82 as 0.32.6",
+                "roxblnfk/unpoly": "^1.8",
+                "spiral/code-style": "^2.3",
+                "testo/bridge-infection": "0.1 - 1",
+                "testo/testo": "0.1 - 1",
+                "vimeo/psalm": "^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "LLM\\Skills\\Composer\\SkillsPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "LLM\\Skills\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin",
+                    "email": "roxblnfk@gmail.com"
+                }
+            ],
+            "description": "AI skills discovery and management system for LLM agents",
+            "keywords": [
+                "agents",
+                "ai",
+                "ai-agents",
+                "ai-skills",
+                "claude-code",
+                "dev",
+                "llm",
+                "llm-agents",
+                "skills"
+            ],
+            "support": {
+                "issues": "https://github.com/roxblnfk/skills/issues",
+                "source": "https://github.com/roxblnfk/skills"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-07-08T22:20:08+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "14.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "82f6e49ff224e2cde923d74425e583a883910783"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/82f6e49ff224e2cde923d74425e583a883910783",
+                "reference": "82f6e49ff224e2cde923d74425e583a883910783",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.8.0",
+                "php": ">=8.4",
+                "phpunit/php-text-template": "^6.0",
+                "sebastian/complexity": "^6.0",
+                "sebastian/environment": "^9.3.2",
+                "sebastian/git-state": "^1.0",
+                "sebastian/lines-of-code": "^5.0.1",
+                "sebastian/version": "^7.0",
+                "theseer/tokenizer": "^2.0.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.2.2"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "14.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-06T15:04:02+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
+                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:33:26+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88",
+                "reference": "42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^13.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-invoker",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:34:47+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "a47af19f93f76aa3368303d752aa5272ca3299f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/a47af19f93f76aa3368303d752aa5272ca3299f4",
+                "reference": "a47af19f93f76aa3368303d752aa5272ca3299f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-text-template",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:36:37+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "9.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/a0e12065831f6ab0d83120dc61513eb8d9a966f6",
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/9.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-timer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:37:53+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "13.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "2beef9f448c9e04914a273c89ff6d039f8b97bc8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2beef9f448c9e04914a273c89ff6d039f8b97bc8",
+                "reference": "2beef9f448c9e04914a273c89ff6d039f8b97bc8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.4.1",
+                "phpunit/php-code-coverage": "^14.2.3",
+                "phpunit/php-file-iterator": "^7.0.0",
+                "phpunit/php-invoker": "^7.0.0",
+                "phpunit/php-text-template": "^6.0.0",
+                "phpunit/php-timer": "^9.0.0",
+                "sebastian/cli-parser": "^5.0.0",
+                "sebastian/comparator": "^8.3.0",
+                "sebastian/diff": "^9.0",
+                "sebastian/environment": "^9.3.2",
+                "sebastian/exporter": "^8.1.1",
+                "sebastian/file-filter": "^1.0",
+                "sebastian/git-state": "^1.0",
+                "sebastian/global-state": "^9.0.1",
+                "sebastian/object-enumerator": "^8.0.0",
+                "sebastian/recursion-context": "^8.0.0",
+                "sebastian/type": "^7.0.1",
+                "sebastian/version": "^7.0.0",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "13.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-25T06:59:14+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "48a4654fa5e48c1c81214e9930048a572d4b23ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/48a4654fa5e48c1c81214e9930048a572d4b23ca",
+                "reference": "48a4654fa5e48c1c81214e9930048a572d4b23ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:39:44+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "8.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "c025fc7604afab3f195fab7cdaf72327331af241"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c025fc7604afab3f195fab7cdaf72327331af241",
+                "reference": "c025fc7604afab3f195fab7cdaf72327331af241",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.4",
+                "sebastian/diff": "^9.0",
+                "sebastian/exporter": "^8.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.2"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/8.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T03:06:45+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "c5651c795c98093480df79350cb050813fc7a2f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/c5651c795c98093480df79350cb050813fc7a2f3",
+                "reference": "c5651c795c98093480df79350cb050813fc7a2f3",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/complexity",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:41:32+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "9.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "a3fb6a298a265ff487a91bbea46e03cd01dbb226"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/a3fb6a298a265ff487a91bbea46e03cd01dbb226",
+                "reference": "a3fb6a298a265ff487a91bbea46e03cd01dbb226",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.2",
+                "symfony/process": "^7.4.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/9.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/diff",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T03:04:51+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "9.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e",
+                "reference": "6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.1.11"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/9.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:41:38+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "8.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
+                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.4",
+                "sebastian/recursion-context": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/8.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-13T11:35:11+00:00"
+        },
+        {
+            "name": "sebastian/file-filter",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/file-filter.git",
+                "reference": "33a26f394330f6faa7684bb9cc73afb7727aae93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/file-filter/zipball/33a26f394330f6faa7684bb9cc73afb7727aae93",
+                "reference": "33a26f394330f6faa7684bb9cc73afb7727aae93",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for filtering files",
+            "homepage": "https://github.com/sebastianbergmann/file-filter",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/file-filter/issues",
+                "security": "https://github.com/sebastianbergmann/file-filter/security/policy",
+                "source": "https://github.com/sebastianbergmann/file-filter/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/file-filter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-22T07:20:04+00:00"
+        },
+        {
+            "name": "sebastian/git-state",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/git-state.git",
+                "reference": "792a952e0eba55b6960a48aeceb9f371aad1f76b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/git-state/zipball/792a952e0eba55b6960a48aeceb9f371aad1f76b",
+                "reference": "792a952e0eba55b6960a48aeceb9f371aad1f76b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for describing the state of a Git checkout",
+            "homepage": "https://github.com/sebastianbergmann/git-state",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/git-state/issues",
+                "security": "https://github.com/sebastianbergmann/git-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/git-state/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/git-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-21T12:54:28+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "9.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "ba68ba79da690cf7eddefd3ce5b78b20b9ba9945"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ba68ba79da690cf7eddefd3ce5b78b20b9ba9945",
+                "reference": "ba68ba79da690cf7eddefd3ce5b78b20b9ba9945",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "sebastian/object-reflector": "^6.0",
+                "sebastian/recursion-context": "^8.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^13.1.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/9.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-01T15:11:33+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d1b6f8fce682505dbd048977f1abedf1b8ad3ff8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d1b6f8fce682505dbd048977f1abedf1b8ad3ff8",
+                "reference": "d1b6f8fce682505dbd048977f1abedf1b8ad3ff8",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.8.0",
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/lines-of-code",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-09T08:42:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "8.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "b39ab125fd9a7434b0ecbc4202eebce11a98cfc5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/b39ab125fd9a7434b0ecbc4202eebce11a98cfc5",
+                "reference": "b39ab125fd9a7434b0ecbc4202eebce11a98cfc5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "sebastian/object-reflector": "^6.0",
+                "sebastian/recursion-context": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/8.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-enumerator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:46:36+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "3ca042c2c60b0eab094f8a1b6a7093f4d4c72200"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/3ca042c2c60b0eab094f8a1b6a7093f4d4c72200",
+                "reference": "3ca042c2c60b0eab094f8a1b6a7093f4d4c72200",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-reflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:47:13+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "8.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "74c5af21f6a5833e91767ca068c4d3dfec15317e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/74c5af21f6a5833e91767ca068c4d3dfec15317e",
+                "reference": "74c5af21f6a5833e91767ca068c4d3dfec15317e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/8.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:51:28+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fee0309275847fefd7636167085e379c1dbf6990",
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.1.10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-20T06:49:11+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/ad37a5552c8e2b88572249fdc19b6da7792e021b",
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/version",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:52:52+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v8.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
+                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v8.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-27T09:05:56+00:00"
+        },
+        {
             "name": "tempest/testing",
             "version": "dev-main",
             "source": {
@@ -6633,6 +8707,999 @@
                 "source": "https://github.com/tempestphp/tempest-testing/tree/main"
             },
             "time": "2026-07-23T11:24:10+00:00"
+        },
+        {
+            "name": "testo/assert",
+            "version": "0.1.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/assert.git",
+                "reference": "aa49c6cef6469eab825fa33d68223ca3a6c03c9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/assert/zipball/aa49c6cef6469eab825fa33d68223ca3a6c03c9d",
+                "reference": "aa49c6cef6469eab825fa33d68223ca3a6c03c9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "testo/testo": "0.10.36 - 1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Assert.php",
+                    "Expect.php"
+                ],
+                "psr-4": {
+                    "Testo\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Assert plugin for the Testo testing framework.",
+            "keywords": [
+                "assert",
+                "testo"
+            ],
+            "support": {
+                "source": "https://github.com/php-testo/assert/tree/0.1.11"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-07-03T10:45:37+00:00"
+        },
+        {
+            "name": "testo/bench",
+            "version": "0.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/bench.git",
+                "reference": "a9fb60c9b33e96fa2ff7dc9f51aa98243bba9bf6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/bench/zipball/a9fb60c9b33e96fa2ff7dc9f51aa98243bba9bf6",
+                "reference": "a9fb60c9b33e96fa2ff7dc9f51aa98243bba9bf6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "testo/data": "^0.1.6",
+                "testo/inline": "^0.1.6",
+                "testo/testo": "0.10.34 - 1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Bench.php"
+                ],
+                "psr-4": {
+                    "Testo\\Bench\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Benchmark plugin for the Testo testing framework.",
+            "keywords": [
+                "benchmark",
+                "testo"
+            ],
+            "support": {
+                "source": "https://github.com/php-testo/bench/tree/0.1.6"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-07-01T13:40:16+00:00"
+        },
+        {
+            "name": "testo/bridge-rector",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/bridge-rector.git",
+                "reference": "765a6528e9fe17dadb896eb506d6eaba64053bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/bridge-rector/zipball/765a6528e9fe17dadb896eb506d6eaba64053bf1",
+                "reference": "765a6528e9fe17dadb896eb506d6eaba64053bf1",
+                "shasum": ""
+            },
+            "require": {
+                "internal/path": "^1.2",
+                "php": ">=8.2",
+                "rector/rector": "^2.0"
+            },
+            "require-dev": {
+                "testo/assert": "^0.1.11",
+                "testo/data": "^0.1.6",
+                "testo/testo": "0.10.38 - 1"
+            },
+            "suggest": {
+                "testo/testo": "To test your Rector rules inline with the bundled Testo\\Bridge\\Rector\\Testing harness."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Testo\\Bridge\\Rector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Rector rules to convert test suites between PEST, PHPUnit and Testo.",
+            "keywords": [
+                "migration",
+                "pest",
+                "phpunit",
+                "rector",
+                "testo"
+            ],
+            "support": {
+                "source": "https://github.com/php-testo/bridge-rector/tree/0.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-07-03T21:48:34+00:00"
+        },
+        {
+            "name": "testo/bridge-symfony-console",
+            "version": "0.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/bridge-symfony-console.git",
+                "reference": "9927456f43b4c01c839d7e24efd7c3c8fa60e68d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/bridge-symfony-console/zipball/9927456f43b4c01c839d7e24efd7c3c8fa60e68d",
+                "reference": "9927456f43b4c01c839d7e24efd7c3c8fa60e68d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/console": "^6.4 || ^7 || ^8.0",
+                "testo/testo": "0.10.33 - 1"
+            },
+            "bin": [
+                "bin/testo"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Testo\\Bridge\\Symfony\\Console\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Symfony Console bridge for the Testo testing framework.",
+            "keywords": [
+                "console",
+                "symfony",
+                "testo"
+            ],
+            "support": {
+                "source": "https://github.com/php-testo/bridge-symfony-console/tree/0.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-06-29T20:42:34+00:00"
+        },
+        {
+            "name": "testo/codecov",
+            "version": "0.1.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/codecov.git",
+                "reference": "cfa3d7cf66318379bac9cb9500b014e61053bfce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/codecov/zipball/cfa3d7cf66318379bac9cb9500b014e61053bfce",
+                "reference": "cfa3d7cf66318379bac9cb9500b014e61053bfce",
+                "shasum": ""
+            },
+            "require": {
+                "ext-xmlwriter": "*",
+                "php": ">=8.2",
+                "testo/data": "^0.1.6",
+                "testo/inline": "^0.1.5",
+                "testo/testo": "0.10.26 - 1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Testo\\Codecov\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Code coverage plugin for the Testo testing framework.",
+            "keywords": [
+                "code-coverage",
+                "testo"
+            ],
+            "support": {
+                "source": "https://github.com/php-testo/codecov/tree/0.1.11"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-06-21T15:50:34+00:00"
+        },
+        {
+            "name": "testo/convention",
+            "version": "0.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/convention.git",
+                "reference": "ad33205f07e29030aaf4d776fa2c068445971b46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/convention/zipball/ad33205f07e29030aaf4d776fa2c068445971b46",
+                "reference": "ad33205f07e29030aaf4d776fa2c068445971b46",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "testo/testo": "0.10.34 - 1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Testo\\Convention\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Naming convention plugin for the Testo testing framework.",
+            "keywords": [
+                "convention",
+                "testo"
+            ],
+            "support": {
+                "source": "https://github.com/php-testo/convention/tree/0.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-07-01T13:40:27+00:00"
+        },
+        {
+            "name": "testo/data",
+            "version": "0.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/data.git",
+                "reference": "18f990382cf6e0d39c05ec060de2c4386d2c05de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/data/zipball/18f990382cf6e0d39c05ec060de2c4386d2c05de",
+                "reference": "18f990382cf6e0d39c05ec060de2c4386d2c05de",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "testo/filter": "^0.1.2",
+                "testo/testo": "0.10.19 - 1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Testo\\Data\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Data provider plugin for the Testo testing framework.",
+            "keywords": [
+                "data-provider",
+                "testo"
+            ],
+            "support": {
+                "source": "https://github.com/php-testo/data/tree/0.1.6"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-06-07T19:36:52+00:00"
+        },
+        {
+            "name": "testo/filter",
+            "version": "0.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/filter.git",
+                "reference": "6e3682e342ff5b6847d49a5d66a07c8176693141"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/filter/zipball/6e3682e342ff5b6847d49a5d66a07c8176693141",
+                "reference": "6e3682e342ff5b6847d49a5d66a07c8176693141",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "testo/testo": "0.10.33 - 1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Filter.php"
+                ],
+                "psr-4": {
+                    "Testo\\Filter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Test filtering plugin for the Testo testing framework.",
+            "keywords": [
+                "filter",
+                "testo"
+            ],
+            "support": {
+                "source": "https://github.com/php-testo/filter/tree/0.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-06-29T20:41:56+00:00"
+        },
+        {
+            "name": "testo/inline",
+            "version": "0.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/inline.git",
+                "reference": "26f2604350bd8c7a17bff32cc00b16929f7e1b38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/inline/zipball/26f2604350bd8c7a17bff32cc00b16929f7e1b38",
+                "reference": "26f2604350bd8c7a17bff32cc00b16929f7e1b38",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "testo/assert": "^0.1.10",
+                "testo/data": "^0.1.6",
+                "testo/filter": "^0.1.5",
+                "testo/testo": "0.10.34 - 1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Testo\\Inline\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Inline test plugin for the Testo testing framework.",
+            "keywords": [
+                "inline",
+                "testo"
+            ],
+            "support": {
+                "source": "https://github.com/php-testo/inline/tree/0.1.6"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-07-01T13:40:50+00:00"
+        },
+        {
+            "name": "testo/lifecycle",
+            "version": "0.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/lifecycle.git",
+                "reference": "961ae522548719aa74d7484c335b0f7b0e080638"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/lifecycle/zipball/961ae522548719aa74d7484c335b0f7b0e080638",
+                "reference": "961ae522548719aa74d7484c335b0f7b0e080638",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "testo/testo": "0.10.34 - 1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Testo\\Lifecycle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Lifecycle hooks plugin for the Testo testing framework.",
+            "keywords": [
+                "lifecycle",
+                "testo"
+            ],
+            "support": {
+                "source": "https://github.com/php-testo/lifecycle/tree/0.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-07-01T13:40:46+00:00"
+        },
+        {
+            "name": "testo/repeat",
+            "version": "0.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/repeat.git",
+                "reference": "0e6a74716e34e7d85710189347ff14aaaac81d21"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/repeat/zipball/0e6a74716e34e7d85710189347ff14aaaac81d21",
+                "reference": "0e6a74716e34e7d85710189347ff14aaaac81d21",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "testo/testo": "0.10.19 - 1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Repeat.php"
+                ],
+                "psr-4": {
+                    "Testo\\Repeat\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Repeat policy plugin for the Testo testing framework.",
+            "keywords": [
+                "repeat",
+                "test",
+                "testo"
+            ],
+            "support": {
+                "source": "https://github.com/php-testo/repeat/tree/0.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-06-07T19:36:04+00:00"
+        },
+        {
+            "name": "testo/retry",
+            "version": "0.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/retry.git",
+                "reference": "4394270c794528b7967ee39bb5151ece52b4436b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/retry/zipball/4394270c794528b7967ee39bb5151ece52b4436b",
+                "reference": "4394270c794528b7967ee39bb5151ece52b4436b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "testo/testo": "0.10.19 - 1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Retry.php"
+                ],
+                "psr-4": {
+                    "Testo\\Retry\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Retry policy plugin for the Testo testing framework.",
+            "keywords": [
+                "retry",
+                "testo"
+            ],
+            "support": {
+                "source": "https://github.com/php-testo/retry/tree/0.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-06-07T19:36:25+00:00"
+        },
+        {
+            "name": "testo/test",
+            "version": "0.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/test.git",
+                "reference": "a67bb2c742936c6180175b3eda7baec8b9990954"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/test/zipball/a67bb2c742936c6180175b3eda7baec8b9990954",
+                "reference": "a67bb2c742936c6180175b3eda7baec8b9990954",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "testo/testo": "0.10.34 - 1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Test.php"
+                ],
+                "psr-4": {
+                    "Testo\\Test\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "Test attribute plugin for the Testo testing framework.",
+            "keywords": [
+                "test",
+                "testo"
+            ],
+            "support": {
+                "source": "https://github.com/php-testo/test/tree/0.1.6"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-07-01T13:41:02+00:00"
+        },
+        {
+            "name": "testo/testo",
+            "version": "0.10.38",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-testo/testo.git",
+                "reference": "2117f45691b7bfcf29a05850ed1ce8ba2895d534"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-testo/testo/zipball/2117f45691b7bfcf29a05850ed1ce8ba2895d534",
+                "reference": "2117f45691b7bfcf29a05850ed1ce8ba2895d534",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "internal/destroy": "^1.0",
+                "internal/path": "^1.2",
+                "php": ">=8.2",
+                "psr/container": "1 - 2",
+                "psr/event-dispatcher": "^1.0",
+                "psr/log": "^2.0 || ^3.0",
+                "symfony/console": "^6.4 || ^7 || ^8.0",
+                "symfony/finder": "^6.4 || ^7 || ^8.0",
+                "testo/assert": "^0.1.11",
+                "testo/bench": "^0.1.6",
+                "testo/bridge-symfony-console": "^0.1.8",
+                "testo/codecov": "^0.1.11",
+                "testo/convention": "^0.1.4",
+                "testo/data": "^0.1.6",
+                "testo/filter": "^0.1.5",
+                "testo/inline": "^0.1.6",
+                "testo/lifecycle": "^0.1.5",
+                "testo/repeat": "^0.1.8",
+                "testo/retry": "^0.1.4",
+                "testo/test": "^0.1.6",
+                "yiisoft/injector": "^1.2"
+            },
+            "replace": {
+                "internal/container": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8",
+                "buggregator/trap": "^1.10",
+                "internal/dload": "^1.6",
+                "llm/skills": "^1.3",
+                "rector/rector": "^2.5.2",
+                "roxblnfk/unpoly": "1.8.2",
+                "testo/bridge-infection": "^0.1.8",
+                "testo/bridge-mockery": "^0.1.1",
+                "testo/bridge-rector": "^0.2.0",
+                "testo/facade": "^0.1.1"
+            },
+            "suggest": {
+                "llm/skills": "Ship Testo's bundled AI-agent skills into your project's skills directory automatically.",
+                "testo/bridge-infection": "Provides integration with Infection PHP mutation testing framework.",
+                "testo/bridge-mockery": "Provides integration with the Mockery mocking framework."
+            },
+            "type": "library",
+            "extra": {
+                "skills": {
+                    "source": "skills"
+                },
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false,
+                    "target-directory": "tools"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Testo\\": "core/",
+                    "Internal\\Container\\": "internal/container/src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                }
+            ],
+            "description": "A lightweight PHP testing framework.",
+            "homepage": "https://php-testo.github.io/",
+            "keywords": [
+                "dev",
+                "test",
+                "testing",
+                "tests"
+            ],
+            "support": {
+                "docs": "https://php-testo.github.io/",
+                "issues": "https://github.com/php-testo/testo/issues",
+                "source": "https://github.com/php-testo/testo"
+            },
+            "funding": [
+                {
+                    "url": "https://boosty.to/roxblnfk",
+                    "type": "boosty"
+                }
+            ],
+            "time": "2026-07-03T21:48:04+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-08T11:19:18+00:00"
+        },
+        {
+            "name": "yiisoft/injector",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/yiisoft/injector.git",
+                "reference": "d3f718256b734933670ad11143cca724d340fc90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/yiisoft/injector/zipball/d3f718256b734933670ad11143cca724d340fc90",
+                "reference": "d3f718256b734933670ad11143cca724d340fc90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "7.4 - 8.5"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.3",
+                "maglnet/composer-require-checker": "^3.8 || ^4.2",
+                "phpbench/phpbench": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "psr/container": "^1.0 || ^2.0",
+                "rector/rector": "^2.0.10",
+                "spatie/phpunit-watcher": "^1.23",
+                "yiisoft/test-support": "^1.4 || ^3.1"
+            },
+            "suggest": {
+                "psr/container": "For automatic resolving of dependencies"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true,
+                    "target-directory": "tools"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Yiisoft\\Injector\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "PSR-11 compatible injector. Executes a callable and makes an instances by injecting dependencies from a given DI container.",
+            "homepage": "https://www.yiiframework.com/",
+            "keywords": [
+                "PSR-11",
+                "dependency injection",
+                "di",
+                "injector",
+                "reflection"
+            ],
+            "support": {
+                "chat": "https://t.me/yii3en",
+                "forum": "https://www.yiiframework.com/forum/",
+                "irc": "ircs://irc.libera.chat:6697/yii",
+                "issues": "https://github.com/yiisoft/injector/issues?state=open",
+                "source": "https://github.com/yiisoft/injector",
+                "wiki": "https://www.yiiframework.com/wiki/"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/yiisoft",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/yiisoft",
+                    "type": "opencollective"
+                }
+            ],
+            "time": "2025-12-01T11:14:17+00:00"
         }
     ],
     "aliases": [],

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
 >
   <testsuites>
     <testsuite name="Unit">
-      <directory suffix="Test.php">./tests</directory>
+      <directory suffix="Test.php">./phpunit</directory>
     </testsuite>
   </testsuites>
   <coverage/>

--- a/phpunit/Analytics/TestsAnalytics.php
+++ b/phpunit/Analytics/TestsAnalytics.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\PHPUnit\Analytics;
+
+use App\Analytics\PageVisited;
+use DateTimeImmutable;
+
+use function Tempest\EventBus\event;
+
+trait TestsAnalytics
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->database->reset();
+    }
+
+    private function triggerVisit(
+        string $date = '2026-01-01 10:00:10',
+        string $uri = 'https://example.com',
+    ): void {
+        event(new PageVisited(
+            url: $uri,
+            visitedAt: new DateTimeImmutable($date),
+            ip: '127.0.0.1',
+            userAgent: 'Test',
+            raw: 'Test',
+        ));
+    }
+}

--- a/phpunit/Analytics/VisitsPerDay/VisitsPerDayProjectorTest.php
+++ b/phpunit/Analytics/VisitsPerDay/VisitsPerDayProjectorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\PHPUnit\Analytics\VisitsPerDay;
+
+use App\Analytics\VisitsPerDay\VisitsPerDayProjector;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Analytics\TestsAnalytics;
+use Tests\PHPUnit\IntegrationTestCase;
+
+class VisitsPerDayProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    #[Test]
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-01');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_day',
+            date: '2026-01-01 00:00:00',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-01');
+        $this->triggerVisit('2026-01-02');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_day',
+            date: '2026-01-01 00:00:00',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_day',
+            date: '2026-01-02 00:00:00',
+            count: 1,
+        );
+    }
+
+    #[Test]
+    public function replay_test(): void
+    {
+        $this->triggerVisit();
+        $this->triggerVisit();
+        $this->triggerVisit();
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerDayProjector::class))->assertSuccess();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_day',
+            date: '2026-01-01 00:00:00',
+            count: 3,
+        );
+    }
+}

--- a/phpunit/Analytics/VisitsPerHour/VisitsPerHourProjectorTest.php
+++ b/phpunit/Analytics/VisitsPerHour/VisitsPerHourProjectorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\PHPUnit\Analytics\VisitsPerHour;
+
+use App\Analytics\VisitsPerMinute\VisitsPerMinuteProjector;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Analytics\TestsAnalytics;
+use Tests\PHPUnit\IntegrationTestCase;
+
+class VisitsPerHourProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    #[Test]
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-01 01:10:00');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_hour',
+            hour: '2026-01-01 01:00:00',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-01 01:10:00');
+        $this->triggerVisit('2026-01-01 02:10:00');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_hour',
+            hour: '2026-01-01 01:00:00',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_hour',
+            hour: '2026-01-01 02:00:00',
+            count: 1,
+        );
+    }
+
+    #[Test]
+    public function replay_test(): void
+    {
+        $this->triggerVisit('2026-01-01 01:00:00');
+        $this->triggerVisit('2026-01-01 01:00:00');
+        $this->triggerVisit('2026-01-01 01:00:00');
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerMinuteProjector::class))->assertSuccess();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_hour',
+            hour: '2026-01-01 01:00:00',
+            count: 3,
+        );
+    }
+}

--- a/phpunit/Analytics/VisitsPerMinute/VisitsPerMinuteProjectorTest.php
+++ b/phpunit/Analytics/VisitsPerMinute/VisitsPerMinuteProjectorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\PHPUnit\Analytics\VisitsPerMinute;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Analytics\TestsAnalytics;
+use Tests\PHPUnit\IntegrationTestCase;
+
+class VisitsPerMinuteProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    #[Test]
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-01 10:10:40');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_minute',
+            time: '2026-01-01 10:10:00',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-01 10:10:30');
+        $this->triggerVisit('2026-01-01 10:11:30');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_minute',
+            time: '2026-01-01 10:10:00',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_minute',
+            time: '2026-01-01 10:11:00',
+            count: 1,
+        );
+    }
+
+    #[Test]
+    public function replay_test(): void
+    {
+        $this->triggerVisit('2026-01-01 10:10:40');
+        $this->triggerVisit('2026-01-01 10:10:41');
+        $this->triggerVisit('2026-01-01 10:10:42');
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerMinuteProjectorTest::class))->assertSuccess();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_minute',
+            time: '2026-01-01 10:10:00',
+            count: 3,
+        );
+    }
+}

--- a/phpunit/Analytics/VisitsPerMonth/VisitsPerMonthProjectorTest.php
+++ b/phpunit/Analytics/VisitsPerMonth/VisitsPerMonthProjectorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\PHPUnit\Analytics\VisitsPerMonth;
+
+use App\Analytics\VisitsPerMonth\VisitsPerMonthProjector;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Analytics\TestsAnalytics;
+use Tests\PHPUnit\IntegrationTestCase;
+
+class VisitsPerMonthProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    #[Test]
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-05');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_month',
+            date: '2026-01-01',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-10');
+        $this->triggerVisit('2026-02-10');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_month',
+            date: '2026-01-01',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_month',
+            date: '2026-02-01',
+            count: 1,
+        );
+    }
+
+    #[Test]
+    public function replay_test(): void
+    {
+        $this->triggerVisit('2026-01-10');
+        $this->triggerVisit('2026-01-10');
+        $this->triggerVisit('2026-01-10');
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerMonthProjector::class))->assertSuccess();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_month',
+            date: '2026-01-01',
+            count: 3,
+        );
+    }
+}

--- a/phpunit/Analytics/VisitsPerPostPerDay/VisitsPerPostPerDayProjectorTest.php
+++ b/phpunit/Analytics/VisitsPerPostPerDay/VisitsPerPostPerDayProjectorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\PHPUnit\Analytics\VisitsPerPostPerDay;
+
+use App\Analytics\VisitsPerPostPerDay\VisitsPerPostPerDayProjector;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Analytics\TestsAnalytics;
+use Tests\PHPUnit\IntegrationTestCase;
+
+class VisitsPerPostPerDayProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    #[Test]
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-05 10:00:00', '/a');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-05 00:00:00',
+            uri: '/a',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-05 10:00:00', '/a');
+        $this->triggerVisit('2026-01-05 10:00:00', '/b');
+        $this->triggerVisit('2026-01-06 10:00:00', '/a');
+        $this->triggerVisit('2026-01-06 10:00:00', '/b');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-05 00:00:00',
+            uri: '/a',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-05 00:00:00',
+            uri: '/b',
+            count: 1,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-06 00:00:00',
+            uri: '/a',
+            count: 1,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-06 00:00:00',
+            uri: '/b',
+            count: 1,
+        );
+    }
+
+    #[Test]
+    public function replay_test(): void
+    {
+        $this->triggerVisit('2026-01-10 10:00:00', '/a');
+        $this->triggerVisit('2026-01-10 10:00:00', '/a');
+        $this->triggerVisit('2026-01-10 10:00:00', '/b');
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerPostPerDayProjector::class))->assertSuccess();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-10 00:00:00',
+            uri: '/a',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-10 00:00:00',
+            uri: '/b',
+            count: 1,
+        );
+    }
+}

--- a/phpunit/Analytics/VisitsPerPostPerWeek/VisitsPerPostPerWeekProjectorTest.php
+++ b/phpunit/Analytics/VisitsPerPostPerWeek/VisitsPerPostPerWeekProjectorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\PHPUnit\Analytics\VisitsPerPostPerWeek;
+
+use App\Analytics\VisitsPerMonth\VisitsPerMonthProjector;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Analytics\TestsAnalytics;
+use Tests\PHPUnit\IntegrationTestCase;
+
+class VisitsPerPostPerWeekProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    #[Test]
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-06 ', '/a');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-05',
+            uri: '/a',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-06 ', '/a');
+        $this->triggerVisit('2026-01-06 ', '/b');
+        $this->triggerVisit('2026-01-13 ', '/a');
+        $this->triggerVisit('2026-01-13 ', '/b');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-05',
+            uri: '/a',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-05',
+            uri: '/b',
+            count: 1,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-12',
+            uri: '/a',
+            count: 1,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-12',
+            uri: '/b',
+            count: 1,
+        );
+    }
+
+    #[Test]
+    public function replay_test(): void
+    {
+        $this->triggerVisit('2026-01-06 ', '/a');
+        $this->triggerVisit('2026-01-06 ', '/a');
+        $this->triggerVisit('2026-01-06 ', '/b');
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerMonthProjector::class))->assertSuccess();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-05',
+            uri: '/a',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-05',
+            uri: '/b',
+            count: 1,
+        );
+    }
+}

--- a/phpunit/Analytics/VisitsPerYear/VisitsPerYearProjectorTest.php
+++ b/phpunit/Analytics/VisitsPerYear/VisitsPerYearProjectorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\PHPUnit\Analytics\VisitsPerYear;
+
+use App\Analytics\VisitsPerYear\VisitsPerYearProjector;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Analytics\TestsAnalytics;
+use Tests\PHPUnit\IntegrationTestCase;
+
+class VisitsPerYearProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    #[Test]
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-05');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_year',
+            date: '2026-01-01',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-10');
+        $this->triggerVisit('2025-02-10');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_year',
+            date: '2026-01-01',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_year',
+            date: '2025-01-01',
+            count: 1,
+        );
+    }
+
+    #[Test]
+    public function replay_test(): void
+    {
+        $this->triggerVisit('2026-01-10');
+        $this->triggerVisit('2026-01-10');
+        $this->triggerVisit('2026-01-10');
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerYearProjector::class))->assertSuccess();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_year',
+            date: '2026-01-01',
+            count: 3,
+        );
+    }
+}

--- a/phpunit/Dungeon/Cards/BeaconMajorTest.php
+++ b/phpunit/Dungeon/Cards/BeaconMajorTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\BeaconMajor;
+use App\Dungeon\Events\CardPlayed;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\DwellerUpdated;
+use App\Dungeon\Events\PassiveCardUnset;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class BeaconMajorTest extends DungeonTest
+{
+    // -------------------------------------------------------------------------
+    // play()
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function play_shows_all_hidden_dwellers(): void
+    {
+        $card = new BeaconMajor();
+        $point = new Point(3, 0);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $card->play($this->dungeon);
+
+        $this->assertTrue($dweller->isVisible);
+        $this->eventBus->assertDispatched(DwellerUpdated::class);
+    }
+
+    #[Test]
+    public function play_does_nothing_when_no_dwellers_exist(): void
+    {
+        $card = new BeaconMajor();
+        $this->dungeon->dwellers = []; // clear initial dungeon dwellers
+
+        $card->play($this->dungeon);
+
+        $this->eventBus->assertNotDispatched(DwellerUpdated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // handle() — PlayerMoved
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function handle_decrements_count_on_player_moved(): void
+    {
+        $card = new BeaconMajor();
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->assertSame(24, $card->count);
+    }
+
+    #[Test]
+    public function handle_updates_card_on_player_moved(): void
+    {
+        $card = new BeaconMajor();
+        $this->dungeon->setPassiveCard($card);
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function handle_shows_dwellers_while_count_is_above_zero(): void
+    {
+        $card = new BeaconMajor();
+        $point = new Point(3, 0);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->assertTrue($dweller->isVisible);
+        $this->assertSame(24, $card->count);
+    }
+
+    #[Test]
+    public function handle_hides_dweller_outside_visibility_radius_when_count_reaches_zero(): void
+    {
+        $card = new BeaconMajor();
+        $card->count = 1;
+        $this->dungeon->setPassiveCard($card);
+
+        // Dweller far outside visibility radius (default radius is 5)
+        $farPoint = new Point(20, 0);
+        $this->dungeon->spawnDweller($farPoint);
+        $dweller = $this->dungeon->getDweller($farPoint);
+        $dweller->isVisible = true;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->assertSame(0, $card->count);
+        $this->assertFalse($dweller->isVisible);
+        $this->assertNull($this->dungeon->passiveCard);
+    }
+
+    #[Test]
+    public function handle_does_not_hide_dweller_inside_visibility_radius_when_count_reaches_zero(): void
+    {
+        $card = new BeaconMajor();
+        $card->count = 1;
+        $this->dungeon->setPassiveCard($card);
+
+        // Dweller within visibility radius (default radius is 5)
+        $nearPoint = new Point(2, 0);
+        $this->dungeon->spawnDweller($nearPoint);
+        $dweller = $this->dungeon->getDweller($nearPoint);
+        $dweller->isVisible = true;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->assertSame(0, $card->count);
+        $this->assertTrue($dweller->isVisible);
+        $this->assertNull($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PassiveCardUnset::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // handle() — CardPlayed
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function handle_does_not_decrement_count_on_card_played(): void
+    {
+        $card = new BeaconMajor();
+        $this->dungeon->setPassiveCard($card);
+
+        $card->handle($this->dungeon, new CardPlayed($card));
+
+        $this->assertSame(25, $card->count);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function handle_shows_dwellers_on_card_played(): void
+    {
+        $card = new BeaconMajor();
+        $point = new Point(3, 0);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $card->handle($this->dungeon, new CardPlayed($card));
+
+        $this->assertTrue($dweller->isVisible);
+    }
+
+    // -------------------------------------------------------------------------
+    // handle() — other events
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new BeaconMajor();
+
+        $card->handle(
+            $this->dungeon,
+            new TileGenerated(
+                new Tile(new Point(1, 0)),
+            ),
+        );
+
+        $this->assertSame(25, $card->count);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/phpunit/Dungeon/Cards/BeaconMinorTest.php
+++ b/phpunit/Dungeon/Cards/BeaconMinorTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\BeaconMinor;
+use App\Dungeon\Events\CardPlayed;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\DwellerUpdated;
+use App\Dungeon\Events\PassiveCardUnset;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class BeaconMinorTest extends DungeonTest
+{
+    // -------------------------------------------------------------------------
+    // play()
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function play_shows_all_hidden_dwellers(): void
+    {
+        $card = new BeaconMinor();
+        $point = new Point(3, 0);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $card->play($this->dungeon);
+
+        $this->assertTrue($dweller->isVisible);
+        $this->eventBus->assertDispatched(DwellerUpdated::class);
+    }
+
+    #[Test]
+    public function play_does_nothing_when_no_dwellers_exist(): void
+    {
+        $card = new BeaconMinor();
+        $this->dungeon->dwellers = [];
+
+        $card->play($this->dungeon);
+
+        $this->eventBus->assertNotDispatched(DwellerUpdated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // handle() — PlayerMoved
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function handle_decrements_count_on_player_moved(): void
+    {
+        $card = new BeaconMinor();
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->assertSame(9, $card->count);
+    }
+
+    #[Test]
+    public function handle_updates_card_on_player_moved(): void
+    {
+        $card = new BeaconMinor();
+        $this->dungeon->setPassiveCard($card);
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function handle_shows_dwellers_while_count_is_above_zero(): void
+    {
+        $card = new BeaconMinor();
+        $point = new Point(3, 0);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->assertTrue($dweller->isVisible);
+        $this->assertSame(9, $card->count);
+    }
+
+    #[Test]
+    public function handle_hides_dweller_outside_visibility_radius_when_count_reaches_zero(): void
+    {
+        $card = new BeaconMinor();
+        $card->count = 1;
+        $this->dungeon->setPassiveCard($card);
+
+        $farPoint = new Point(20, 0);
+        $this->dungeon->spawnDweller($farPoint);
+        $dweller = $this->dungeon->getDweller($farPoint);
+        $dweller->isVisible = true;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->assertSame(0, $card->count);
+        $this->assertFalse($dweller->isVisible);
+        $this->assertNull($this->dungeon->passiveCard);
+    }
+
+    #[Test]
+    public function handle_does_not_hide_dweller_inside_visibility_radius_when_count_reaches_zero(): void
+    {
+        $card = new BeaconMinor();
+        $card->count = 1;
+        $this->dungeon->setPassiveCard($card);
+
+        $nearPoint = new Point(2, 0);
+        $this->dungeon->spawnDweller($nearPoint);
+        $dweller = $this->dungeon->getDweller($nearPoint);
+        $dweller->isVisible = true;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->assertSame(0, $card->count);
+        $this->assertTrue($dweller->isVisible);
+        $this->assertNull($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PassiveCardUnset::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // handle() — CardPlayed
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function handle_does_not_decrement_count_on_card_played(): void
+    {
+        $card = new BeaconMinor();
+        $this->dungeon->setPassiveCard($card);
+
+        $card->handle($this->dungeon, new CardPlayed($card));
+
+        $this->assertSame(10, $card->count);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // handle() — other events
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new BeaconMinor();
+
+        $card->handle(
+            $this->dungeon,
+            new TileGenerated(
+                new Tile(new Point(1, 0)),
+            ),
+        );
+
+        $this->assertSame(10, $card->count);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/phpunit/Dungeon/Cards/BreakthroughMajorTest.php
+++ b/phpunit/Dungeon/Cards/BreakthroughMajorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\BreakthroughMajor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerStabilityDecreased;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class BreakthroughMajorTest extends DungeonTest
+{
+    #[Test]
+    public function interact_with_tile_removes_walls_and_decreases_stability(): void
+    {
+        $card = new BreakthroughMajor();
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+        $this->dungeon->stability = 80;
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertSame(70, $this->dungeon->stability);
+        $this->assertSame(2, $card->count);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            $this->assertSame(10, $event->amount);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function interact_with_tile_unsets_active_card_when_count_reaches_zero(): void
+    {
+        $card = new BreakthroughMajor();
+        $card->count = 1;
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertSame(0, $card->count);
+        $this->assertNull($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    #[Test]
+    public function interact_with_tile_does_not_unset_active_card_while_count_is_above_zero(): void
+    {
+        $card = new BreakthroughMajor(); // count = 3
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertNotNull($this->dungeon->activeCard);
+        $this->eventBus->assertNotDispatched(ActiveCardUnset::class);
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_false_for_collapsed_tile(): void
+    {
+        $card = new BreakthroughMajor();
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+
+        $this->assertFalse($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_true_for_normal_tile(): void
+    {
+        $card = new BreakthroughMajor();
+        $tile = new Tile(new Point(1, 0));
+
+        $this->assertTrue($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/phpunit/Dungeon/Cards/BreakthroughMinorTest.php
+++ b/phpunit/Dungeon/Cards/BreakthroughMinorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\BreakthroughMinor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerStabilityDecreased;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class BreakthroughMinorTest extends DungeonTest
+{
+    #[Test]
+    public function interact_with_tile_removes_walls_decreases_stability_and_unsets_active_card(): void
+    {
+        $card = new BreakthroughMinor();
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+        $this->dungeon->stability = 80;
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertSame(60, $this->dungeon->stability);
+        $this->assertNull($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            $this->assertSame(20, $event->amount);
+        });
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_false_for_collapsed_tile(): void
+    {
+        $card = new BreakthroughMinor();
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+
+        $this->assertFalse($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_true_for_normal_tile(): void
+    {
+        $card = new BreakthroughMinor();
+        $tile = new Tile(new Point(1, 0));
+
+        $this->assertTrue($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/phpunit/Dungeon/Cards/ChestplateMajorPermanentTest.php
+++ b/phpunit/Dungeon/Cards/ChestplateMajorPermanentTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\ChestplateMajorPermanent;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerHealthDecreased;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Point;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class ChestplateMajorPermanentTest extends DungeonTest
+{
+    #[Test]
+    public function handle_restores_up_to_10_health_on_damage(): void
+    {
+        $card = new ChestplateMajorPermanent();
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(15, 70, null));
+
+        $this->assertSame(80, $this->dungeon->health);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(10, $event->amount);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function handle_restores_only_the_actual_damage_when_damage_is_less_than_10(): void
+    {
+        $card = new ChestplateMajorPermanent();
+        $this->dungeon->health = 95;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(5, 95, null));
+
+        $this->assertSame(100, $this->dungeon->health);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(5, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new ChestplateMajorPermanent();
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerMoved(
+            from: new Point(0, 0),
+            to: new Point(1, 0),
+        ));
+
+        $this->assertSame(70, $this->dungeon->health);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/phpunit/Dungeon/Cards/ChestplateMinorPermanentTest.php
+++ b/phpunit/Dungeon/Cards/ChestplateMinorPermanentTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\ChestplateMinorPermanent;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerHealthDecreased;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Point;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class ChestplateMinorPermanentTest extends DungeonTest
+{
+    #[Test]
+    public function handle_restores_up_to_5_health_on_damage(): void
+    {
+        $card = new ChestplateMinorPermanent();
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(10, 70, null));
+
+        $this->assertSame(75, $this->dungeon->health);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(5, $event->amount);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function handle_restores_only_the_actual_damage_when_damage_is_less_than_5(): void
+    {
+        $card = new ChestplateMinorPermanent();
+        $this->dungeon->health = 98;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(2, 98, null));
+
+        $this->assertSame(100, $this->dungeon->health);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(2, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new ChestplateMinorPermanent();
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerMoved(
+            from: new Point(0, 0),
+            to: new Point(1, 0),
+        ));
+
+        $this->assertSame(70, $this->dungeon->health);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/phpunit/Dungeon/Cards/ClarityTest.php
+++ b/phpunit/Dungeon/Cards/ClarityTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\Clarity;
+use App\Dungeon\Events\PlayerStabilityIncreased;
+use App\Dungeon\Events\VisibilityChanged;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class ClarityTest extends DungeonTest
+{
+    #[Test]
+    public function play_increases_visibility_radius_by_one(): void
+    {
+        $radiusBefore = $this->dungeon->visibilityRadius;
+        $card = new Clarity();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame($radiusBefore + 1, $this->dungeon->visibilityRadius);
+        $this->eventBus->assertDispatched(VisibilityChanged::class, function (VisibilityChanged $event) use ($radiusBefore) {
+            $this->assertSame($radiusBefore + 1, $event->visibilityRadius);
+        });
+    }
+
+    #[Test]
+    public function play_increases_stability_by_20(): void
+    {
+        $this->dungeon->stability = 50;
+        $card = new Clarity();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(70, $this->dungeon->stability);
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            $this->assertSame(20, $event->amount);
+        });
+    }
+}

--- a/phpunit/Dungeon/Cards/EmergencyExitMajorTest.php
+++ b/phpunit/Dungeon/Cards/EmergencyExitMajorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\EmergencyExitMajor;
+use App\Dungeon\Events\PlayerExited;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class EmergencyExitMajorTest extends DungeonTest
+{
+    #[Test]
+    public function play_exits_with_65_percent_of_coins(): void
+    {
+        $this->dungeon->coins = 100;
+        $card = new EmergencyExitMajor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(65, $this->dungeon->coins);
+        $this->assertTrue($this->dungeon->hasEnded);
+        $this->eventBus->assertDispatched(PlayerExited::class, function (PlayerExited $event) {
+            $this->assertSame(65, $event->coins);
+        });
+    }
+
+    #[Test]
+    public function play_exits_without_requiring_origin_tile(): void
+    {
+        $this->dungeon->coins = 0;
+        $card = new EmergencyExitMajor();
+
+        $card->play($this->dungeon);
+
+        $this->assertTrue($this->dungeon->hasEnded);
+    }
+}

--- a/phpunit/Dungeon/Cards/EmergencyExitMinorTest.php
+++ b/phpunit/Dungeon/Cards/EmergencyExitMinorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\EmergencyExitMinor;
+use App\Dungeon\Events\PlayerExited;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class EmergencyExitMinorTest extends DungeonTest
+{
+    #[Test]
+    public function play_exits_with_30_percent_of_coins(): void
+    {
+        $this->dungeon->coins = 100;
+        $card = new EmergencyExitMinor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(30, $this->dungeon->coins);
+        $this->assertTrue($this->dungeon->hasEnded);
+        $this->eventBus->assertDispatched(PlayerExited::class, function (PlayerExited $event) {
+            $this->assertSame(30, $event->coins);
+        });
+    }
+
+    #[Test]
+    public function play_exits_without_requiring_origin_tile(): void
+    {
+        $this->dungeon->coins = 0;
+        $card = new EmergencyExitMinor();
+
+        $card->play($this->dungeon);
+
+        $this->assertTrue($this->dungeon->hasEnded);
+    }
+}

--- a/phpunit/Dungeon/Cards/GreedTest.php
+++ b/phpunit/Dungeon/Cards/GreedTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\Greed;
+use App\Dungeon\Events\PlayerStabilityDecreased;
+use App\Dungeon\Events\TileCoinsCollected;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class GreedTest extends DungeonTest
+{
+    #[Test]
+    public function play_collects_all_coins_from_tiles(): void
+    {
+        $tile = new Tile(new Point(1, 0), coins: 10);
+        $this->dungeon->addTile($tile);
+        $card = new Greed();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(10, $this->dungeon->coins);
+        $this->eventBus->assertDispatched(TileCoinsCollected::class);
+    }
+
+    #[Test]
+    public function play_decreases_stability_by_20(): void
+    {
+        $this->dungeon->stability = 80;
+        $card = new Greed();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(60, $this->dungeon->stability);
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            $this->assertSame(20, $event->amount);
+        });
+    }
+}

--- a/phpunit/Dungeon/Cards/HealMajorTest.php
+++ b/phpunit/Dungeon/Cards/HealMajorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\HealMajor;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class HealMajorTest extends DungeonTest
+{
+    #[Test]
+    public function play_increases_health_by_50(): void
+    {
+        $this->dungeon->health = 40;
+        $card = new HealMajor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(90, $this->dungeon->health);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(50, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function play_is_capped_at_max_health(): void
+    {
+        $this->dungeon->health = 80; // max is 100
+        $card = new HealMajor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(100, $this->dungeon->health);
+    }
+}

--- a/phpunit/Dungeon/Cards/HealMinorTest.php
+++ b/phpunit/Dungeon/Cards/HealMinorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class HealMinorTest extends DungeonTest
+{
+    #[Test]
+    public function play_increases_health_by_25(): void
+    {
+        $this->dungeon->health = 50;
+        $card = new HealMinor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(75, $this->dungeon->health);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(25, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function play_is_capped_at_max_health(): void
+    {
+        $this->dungeon->health = 90;
+        $card = new HealMinor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(100, $this->dungeon->health);
+    }
+}

--- a/phpunit/Dungeon/Cards/HealthIncreaseMajorTest.php
+++ b/phpunit/Dungeon/Cards/HealthIncreaseMajorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\HealthIncreaseMajor;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerMaxHealthIncreased;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class HealthIncreaseMajorTest extends DungeonTest
+{
+    #[Test]
+    public function play_increases_max_health_by_50(): void
+    {
+        $maxHealthBefore = $this->dungeon->maxHealth;
+        $card = new HealthIncreaseMajor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame($maxHealthBefore + 50, $this->dungeon->maxHealth);
+        $this->eventBus->assertDispatched(PlayerMaxHealthIncreased::class, function (PlayerMaxHealthIncreased $event) {
+            $this->assertSame(50, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function play_increases_current_health_by_40(): void
+    {
+        $this->dungeon->health = 10;
+        $this->dungeon->maxHealth = 200; // room to grow
+        $card = new HealthIncreaseMajor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(50, $this->dungeon->health);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(40, $event->amount);
+        });
+    }
+}

--- a/phpunit/Dungeon/Cards/HealthIncreaseMinorTest.php
+++ b/phpunit/Dungeon/Cards/HealthIncreaseMinorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\HealthIncreaseMinor;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerMaxHealthIncreased;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class HealthIncreaseMinorTest extends DungeonTest
+{
+    #[Test]
+    public function play_increases_max_health_by_25(): void
+    {
+        $maxHealthBefore = $this->dungeon->maxHealth;
+        $card = new HealthIncreaseMinor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame($maxHealthBefore + 25, $this->dungeon->maxHealth);
+        $this->eventBus->assertDispatched(PlayerMaxHealthIncreased::class, function (PlayerMaxHealthIncreased $event) {
+            $this->assertSame(25, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function play_increases_current_health_by_15(): void
+    {
+        $this->dungeon->health = 10;
+        $this->dungeon->maxHealth = 200; // room to grow
+        $card = new HealthIncreaseMinor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(25, $this->dungeon->health);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(15, $event->amount);
+        });
+    }
+}

--- a/phpunit/Dungeon/Cards/KillDwellerMajorTest.php
+++ b/phpunit/Dungeon/Cards/KillDwellerMajorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\KillDwellerMajor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\DwellerDespawned;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class KillDwellerMajorTest extends DungeonTest
+{
+    #[Test]
+    public function interact_with_tile_despawns_dweller_at_tile(): void
+    {
+        $card = new KillDwellerMajor();
+        $point = new Point(2, 0);
+        $tile = new Tile($point);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->spawnDweller($point);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertNull($this->dungeon->getDweller($point));
+        $this->eventBus->assertDispatched(DwellerDespawned::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function interact_with_tile_unsets_active_card_after_three_uses(): void
+    {
+        $card = new KillDwellerMajor();
+        $this->dungeon->setActiveCard($card);
+
+        for ($i = 0; $i < 3; $i++) {
+            $point = new Point($i + 1, 0);
+            $tile = new Tile($point);
+            $this->dungeon->addTile($tile);
+            $this->dungeon->spawnDweller($point);
+            $card->interactWithTile($this->dungeon, $tile);
+        }
+
+        $this->assertNull($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    #[Test]
+    public function interact_with_tile_does_not_unset_card_before_three_uses(): void
+    {
+        $card = new KillDwellerMajor();
+        $this->dungeon->setActiveCard($card);
+        $point = new Point(2, 0);
+        $tile = new Tile($point);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->spawnDweller($point);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertNotNull($this->dungeon->activeCard);
+        $this->eventBus->assertNotDispatched(ActiveCardUnset::class);
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_true_when_dweller_is_present(): void
+    {
+        $card = new KillDwellerMajor();
+        $point = new Point(2, 0);
+        $tile = new Tile($point);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->spawnDweller($point);
+
+        $this->assertTrue($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_false_when_no_dweller_present(): void
+    {
+        $card = new KillDwellerMajor();
+        $tile = new Tile(new Point(2, 0));
+
+        $this->assertFalse($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/phpunit/Dungeon/Cards/KillDwellerMinorTest.php
+++ b/phpunit/Dungeon/Cards/KillDwellerMinorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\KillDwellerMinor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\DwellerDespawned;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class KillDwellerMinorTest extends DungeonTest
+{
+    #[Test]
+    public function interact_with_tile_despawns_dweller_and_unsets_active_card(): void
+    {
+        $card = new KillDwellerMinor();
+        $this->dungeon->setActiveCard($card);
+        $point = new Point(2, 0);
+        $tile = new Tile($point);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->spawnDweller($point);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertNull($this->dungeon->getDweller($point));
+        $this->assertNull($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(DwellerDespawned::class);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_true_when_dweller_is_present(): void
+    {
+        $card = new KillDwellerMinor();
+        $point = new Point(2, 0);
+        $tile = new Tile($point);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->spawnDweller($point);
+
+        $this->assertTrue($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_false_when_no_dweller_present(): void
+    {
+        $card = new KillDwellerMinor();
+        $tile = new Tile(new Point(2, 0));
+
+        $this->assertFalse($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/phpunit/Dungeon/Cards/LocateHealthAltarTest.php
+++ b/phpunit/Dungeon/Cards/LocateHealthAltarTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\LocateHealthAltar;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class LocateHealthAltarTest extends DungeonTest
+{
+    #[Test]
+    public function play_generates_tile_at_undiscovered_health_altar(): void
+    {
+        $altarPoint = new Point(5, 5);
+        $this->dungeon->healthAltars[$altarPoint->x][$altarPoint->y] = $altarPoint;
+        $card = new LocateHealthAltar();
+
+        $card->play($this->dungeon);
+
+        $this->assertNotNull($this->dungeon->tryTile($altarPoint));
+        $this->eventBus->assertDispatched(TileGenerated::class, function (TileGenerated $event) use ($altarPoint) {
+            $this->assertTrue($event->tile->point->equals($altarPoint));
+        });
+    }
+
+    #[Test]
+    public function play_skips_altar_that_already_has_a_tile(): void
+    {
+        $altarPoint = new Point(5, 5);
+        $this->dungeon->healthAltars[$altarPoint->x][$altarPoint->y] = $altarPoint;
+        $this->dungeon->generateTile(null, $altarPoint); // already discovered
+        $card = new LocateHealthAltar();
+
+        $card->play($this->dungeon);
+
+        // TileGenerated was dispatched for the pre-generated tile, not by the card
+        $this->eventBus->assertDispatched(TileGenerated::class);
+    }
+
+    #[Test]
+    public function play_does_nothing_when_no_health_altars_exist(): void
+    {
+        $this->dungeon->healthAltars = [];
+        $card = new LocateHealthAltar();
+
+        $card->play($this->dungeon);
+
+        $this->eventBus->assertNotDispatched(TileGenerated::class);
+    }
+}

--- a/phpunit/Dungeon/Cards/LocateManaAltarTest.php
+++ b/phpunit/Dungeon/Cards/LocateManaAltarTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\LocateManaAltar;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class LocateManaAltarTest extends DungeonTest
+{
+    #[Test]
+    public function play_generates_tile_at_undiscovered_mana_altar(): void
+    {
+        $altarPoint = new Point(5, 5);
+        $this->dungeon->manaAltars[$altarPoint->x][$altarPoint->y] = $altarPoint;
+        $card = new LocateManaAltar();
+
+        $card->play($this->dungeon);
+
+        $this->assertNotNull($this->dungeon->tryTile($altarPoint));
+        $this->eventBus->assertDispatched(TileGenerated::class, function (TileGenerated $event) use ($altarPoint) {
+            $this->assertTrue($event->tile->point->equals($altarPoint));
+        });
+    }
+
+    #[Test]
+    public function play_does_nothing_when_no_mana_altars_exist(): void
+    {
+        $this->dungeon->manaAltars = [];
+        $card = new LocateManaAltar();
+
+        $card->play($this->dungeon);
+
+        $this->eventBus->assertNotDispatched(TileGenerated::class);
+    }
+}

--- a/phpunit/Dungeon/Cards/LocateShardTest.php
+++ b/phpunit/Dungeon/Cards/LocateShardTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class LocateShardTest extends DungeonTest
+{
+    #[Test]
+    public function play(): void
+    {
+        // TODO: LocateShard.play() is not yet implemented
+        $this->markTestSkipped('LocateShard is not yet implemented');
+    }
+}

--- a/phpunit/Dungeon/Cards/LocateStabilityAltarTest.php
+++ b/phpunit/Dungeon/Cards/LocateStabilityAltarTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\LocateStabilityAltar;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class LocateStabilityAltarTest extends DungeonTest
+{
+    #[Test]
+    public function play_generates_tile_at_undiscovered_stability_altar(): void
+    {
+        $altarPoint = new Point(5, 5);
+        $this->dungeon->stabilityAltars[$altarPoint->x][$altarPoint->y] = $altarPoint;
+        $card = new LocateStabilityAltar();
+
+        $card->play($this->dungeon);
+
+        $this->assertNotNull($this->dungeon->tryTile($altarPoint));
+        $this->eventBus->assertDispatched(TileGenerated::class, function (TileGenerated $event) use ($altarPoint) {
+            $this->assertTrue($event->tile->point->equals($altarPoint));
+        });
+    }
+
+    #[Test]
+    public function play_does_nothing_when_no_stability_altars_exist(): void
+    {
+        $this->dungeon->stabilityAltars = [];
+        $card = new LocateStabilityAltar();
+
+        $card->play($this->dungeon);
+
+        $this->eventBus->assertNotDispatched(TileGenerated::class);
+    }
+}

--- a/phpunit/Dungeon/Cards/LocateVictoryPointTest.php
+++ b/phpunit/Dungeon/Cards/LocateVictoryPointTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class LocateVictoryPointTest extends DungeonTest
+{
+    #[Test]
+    public function play(): void
+    {
+        // TODO: LocateVictoryPoint.play() is not yet implemented
+        $this->markTestSkipped('LocateVictoryPoint is not yet implemented');
+    }
+}

--- a/phpunit/Dungeon/Cards/ManaIncreaseMajorTest.php
+++ b/phpunit/Dungeon/Cards/ManaIncreaseMajorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\ManaIncreaseMajor;
+use App\Dungeon\Events\PlayerMaxManaIncreased;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class ManaIncreaseMajorTest extends DungeonTest
+{
+    #[Test]
+    public function play_increases_max_mana_by_50(): void
+    {
+        $maxManaBefore = $this->dungeon->maxMana;
+        $card = new ManaIncreaseMajor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame($maxManaBefore + 50, $this->dungeon->maxMana);
+        $this->eventBus->assertDispatched(PlayerMaxManaIncreased::class, function (PlayerMaxManaIncreased $event) {
+            $this->assertSame(50, $event->amount);
+        });
+    }
+}

--- a/phpunit/Dungeon/Cards/ManaIncreaseMinorTest.php
+++ b/phpunit/Dungeon/Cards/ManaIncreaseMinorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\ManaIncreaseMinor;
+use App\Dungeon\Events\PlayerMaxManaIncreased;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class ManaIncreaseMinorTest extends DungeonTest
+{
+    #[Test]
+    public function play_increases_max_mana_by_25(): void
+    {
+        $maxManaBefore = $this->dungeon->maxMana;
+        $card = new ManaIncreaseMinor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame($maxManaBefore + 25, $this->dungeon->maxMana);
+        $this->eventBus->assertDispatched(PlayerMaxManaIncreased::class, function (PlayerMaxManaIncreased $event) {
+            $this->assertSame(25, $event->amount);
+        });
+    }
+}

--- a/phpunit/Dungeon/Cards/ManaPerMoveMinorTest.php
+++ b/phpunit/Dungeon/Cards/ManaPerMoveMinorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\ManaPerMoveMinor;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PassiveCardUnset;
+use App\Dungeon\Events\PlayerManaIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class ManaPerMoveMinorTest extends DungeonTest
+{
+    #[Test]
+    public function handle_grants_10_mana_per_move(): void
+    {
+        $card = new ManaPerMoveMinor();
+        $this->dungeon->mana = 0;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->assertSame(10, $this->dungeon->mana);
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class, function (PlayerManaIncreased $event) {
+            $this->assertSame(10, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function handle_decrements_move_count(): void
+    {
+        $card = new ManaPerMoveMinor(); // moves = 10
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->assertSame(9, $card->moves);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function handle_unsets_passive_card_when_moves_reach_zero(): void
+    {
+        $card = new ManaPerMoveMinor();
+        $card->moves = 1;
+        $this->dungeon->setPassiveCard($card);
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->assertSame(0, $card->moves);
+        $this->assertNull($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PassiveCardUnset::class);
+    }
+
+    #[Test]
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new ManaPerMoveMinor();
+
+        $card->handle(
+            $this->dungeon,
+            new TileGenerated(
+                new Tile(new Point(1, 0)),
+            ),
+        );
+
+        $this->assertSame(10, $card->moves);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/phpunit/Dungeon/Cards/ManaPerMovePermanentTest.php
+++ b/phpunit/Dungeon/Cards/ManaPerMovePermanentTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\ManaPerMovePermanent;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerManaIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class ManaPerMovePermanentTest extends DungeonTest
+{
+    #[Test]
+    public function handle_grants_1_mana_per_move(): void
+    {
+        $card = new ManaPerMovePermanent();
+        $this->dungeon->mana = 0;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->assertSame(1, $this->dungeon->mana);
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class, function (PlayerManaIncreased $event) {
+            $this->assertSame(1, $event->amount);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new ManaPerMovePermanent();
+        $this->dungeon->mana = 0;
+
+        $card->handle(
+            $this->dungeon,
+            new TileGenerated(
+                new Tile(new Point(1, 0)),
+            ),
+        );
+
+        $this->assertSame(0, $this->dungeon->mana);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/phpunit/Dungeon/Cards/ProtectionMajorTest.php
+++ b/phpunit/Dungeon/Cards/ProtectionMajorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\ProtectionMajor;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PassiveCardUnset;
+use App\Dungeon\Events\PlayerHealthDecreased;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Point;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class ProtectionMajorTest extends DungeonTest
+{
+    #[Test]
+    public function handle_absorbs_damage_when_shield_has_enough(): void
+    {
+        $card = new ProtectionMajor(); // toAbsorb = 100
+        $this->dungeon->setPassiveCard($card);
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(30, 70, null));
+
+        $this->assertSame(70, $card->toAbsorb);
+        $this->assertSame(100, $this->dungeon->health);
+        $this->assertNotNull($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(30, $event->amount);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function handle_depletes_shield_and_unsets_passive_card_when_damage_exceeds_absorption(): void
+    {
+        $card = new ProtectionMajor();
+        $card->toAbsorb = 20;
+        $this->dungeon->setPassiveCard($card);
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(30, 70, null));
+
+        // Absorbs 20 (toAbsorb), not the full 30
+        $this->assertSame(90, $this->dungeon->health);
+        $this->assertNull($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PassiveCardUnset::class);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(20, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new ProtectionMajor();
+
+        $card->handle($this->dungeon, new PlayerMoved(
+            from: new Point(0, 0),
+            to: new Point(1, 0),
+        ));
+
+        $this->assertSame(100, $card->toAbsorb);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/phpunit/Dungeon/Cards/ProtectionMinorTest.php
+++ b/phpunit/Dungeon/Cards/ProtectionMinorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\ProtectionMinor;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PassiveCardUnset;
+use App\Dungeon\Events\PlayerHealthDecreased;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Point;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class ProtectionMinorTest extends DungeonTest
+{
+    #[Test]
+    public function handle_absorbs_damage_when_shield_has_enough(): void
+    {
+        $card = new ProtectionMinor(); // toAbsorb = 50
+        $this->dungeon->setPassiveCard($card);
+        $this->dungeon->health = 80;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(20, 80, null));
+
+        $this->assertSame(30, $card->toAbsorb);
+        $this->assertSame(100, $this->dungeon->health);
+        $this->assertNotNull($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(20, $event->amount);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function handle_depletes_shield_and_unsets_passive_card_when_damage_exceeds_absorption(): void
+    {
+        $card = new ProtectionMinor();
+        $card->toAbsorb = 10;
+        $this->dungeon->setPassiveCard($card);
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(30, 70, null));
+
+        // Only absorbs 10 (toAbsorb)
+        $this->assertSame(80, $this->dungeon->health);
+        $this->assertNull($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PassiveCardUnset::class);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(10, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new ProtectionMinor();
+
+        $card->handle($this->dungeon, new PlayerMoved(
+            from: new Point(0, 0),
+            to: new Point(1, 0),
+        ));
+
+        $this->assertSame(50, $card->toAbsorb);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/phpunit/Dungeon/Cards/RumbleMajorTest.php
+++ b/phpunit/Dungeon/Cards/RumbleMajorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\RumbleMajor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerStabilityDecreased;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class RumbleMajorTest extends DungeonTest
+{
+    #[Test]
+    public function interact_with_tile_removes_collapse_and_decreases_stability(): void
+    {
+        $card = new RumbleMajor();
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->stability = 80;
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertFalse($tile->isCollapsed);
+        $this->assertSame(70, $this->dungeon->stability);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            $this->assertSame(10, $event->amount);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function interact_with_tile_unsets_active_card_after_three_uses(): void
+    {
+        $card = new RumbleMajor();
+        $this->dungeon->setActiveCard($card);
+
+        for ($i = 0; $i < 3; $i++) {
+            $tile = new Tile(new Point($i + 1, 0), isCollapsed: true);
+            $this->dungeon->addTile($tile);
+            $card->interactWithTile($this->dungeon, $tile);
+        }
+
+        $this->assertNull($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_true_for_collapsed_tile(): void
+    {
+        $card = new RumbleMajor();
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+
+        $this->assertTrue($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_false_for_normal_tile(): void
+    {
+        $card = new RumbleMajor();
+        $tile = new Tile(new Point(1, 0));
+
+        $this->assertFalse($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/phpunit/Dungeon/Cards/RumbleMinorTest.php
+++ b/phpunit/Dungeon/Cards/RumbleMinorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\RumbleMinor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerStabilityDecreased;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class RumbleMinorTest extends DungeonTest
+{
+    #[Test]
+    public function interact_with_tile_removes_collapse_decreases_stability_and_unsets_active_card(): void
+    {
+        $card = new RumbleMinor();
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->stability = 80;
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertFalse($tile->isCollapsed);
+        $this->assertSame(70, $this->dungeon->stability);
+        $this->assertNull($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            $this->assertSame(10, $event->amount);
+        });
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_true_for_collapsed_tile(): void
+    {
+        $card = new RumbleMinor();
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+
+        $this->assertTrue($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_false_for_normal_tile(): void
+    {
+        $card = new RumbleMinor();
+        $tile = new Tile(new Point(1, 0));
+
+        $this->assertFalse($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/phpunit/Dungeon/Cards/StabilityMajorTest.php
+++ b/phpunit/Dungeon/Cards/StabilityMajorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\StabilityMajor;
+use App\Dungeon\Events\PlayerStabilityIncreased;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class StabilityMajorTest extends DungeonTest
+{
+    #[Test]
+    public function play_increases_stability_by_50(): void
+    {
+        $this->dungeon->stability = 30;
+        $card = new StabilityMajor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(80, $this->dungeon->stability);
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            $this->assertSame(50, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function play_is_capped_at_max_stability(): void
+    {
+        $this->dungeon->stability = 80;
+        $card = new StabilityMajor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(100, $this->dungeon->stability);
+    }
+}

--- a/phpunit/Dungeon/Cards/StabilityMinorTest.php
+++ b/phpunit/Dungeon/Cards/StabilityMinorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\StabilityMinor;
+use App\Dungeon\Events\PlayerStabilityIncreased;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class StabilityMinorTest extends DungeonTest
+{
+    #[Test]
+    public function play_increases_stability_by_25(): void
+    {
+        $this->dungeon->stability = 30;
+        $card = new StabilityMinor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(55, $this->dungeon->stability);
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            $this->assertSame(25, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function play_is_capped_at_max_stability(): void
+    {
+        $this->dungeon->stability = 90;
+        $card = new StabilityMinor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame(100, $this->dungeon->stability);
+    }
+}

--- a/phpunit/Dungeon/Cards/StabilityPerTilePermanentTest.php
+++ b/phpunit/Dungeon/Cards/StabilityPerTilePermanentTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\StabilityPerTilePermanent;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Events\PlayerStabilityIncreased;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class StabilityPerTilePermanentTest extends DungeonTest
+{
+    #[Test]
+    public function handle_grants_1_stability_per_tile_generated(): void
+    {
+        $this->dungeon->stability = 50;
+        $card = new StabilityPerTilePermanent();
+        $tile = new Tile(new Point(5, 5));
+
+        $card->handle($this->dungeon, new TileGenerated($tile));
+
+        $this->assertSame(51, $this->dungeon->stability);
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            $this->assertSame(1, $event->amount);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function handle_ignores_unrelated_events(): void
+    {
+        $this->dungeon->stability = 50;
+        $card = new StabilityPerTilePermanent();
+
+        $card->handle($this->dungeon, new PlayerMoved(
+            from: new Point(0, 0),
+            to: new Point(1, 0),
+        ));
+
+        $this->assertSame(50, $this->dungeon->stability);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/phpunit/Dungeon/Cards/SupportEpicTest.php
+++ b/phpunit/Dungeon/Cards/SupportEpicTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class SupportEpicTest extends DungeonTest
+{
+    #[Test]
+    public function interact_with_tile(): void
+    {
+        // TODO: SupportEpic.interactWithTile() is not yet implemented
+        $this->markTestSkipped('SupportEpic is not yet implemented');
+    }
+}

--- a/phpunit/Dungeon/Cards/SupportMajorTest.php
+++ b/phpunit/Dungeon/Cards/SupportMajorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\SupportMajor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class SupportMajorTest extends DungeonTest
+{
+    #[Test]
+    public function interact_with_tile_marks_tile_as_supported(): void
+    {
+        $card = new SupportMajor();
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertTrue($tile->isSupported);
+        $this->assertSame(24, $card->count);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function interact_with_tile_unsets_active_card_when_count_reaches_zero(): void
+    {
+        $card = new SupportMajor();
+        $card->count = 1;
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertSame(0, $card->count);
+        $this->assertNull($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_false_for_collapsed_tile(): void
+    {
+        $card = new SupportMajor();
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+
+        $this->assertFalse($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_false_for_already_supported_tile(): void
+    {
+        $card = new SupportMajor();
+        $tile = new Tile(new Point(1, 0), isSupported: true);
+
+        $this->assertFalse($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_false_for_origin_tile(): void
+    {
+        $card = new SupportMajor();
+        $tile = new Tile(new Point(0, 0), isOrigin: true);
+
+        $this->assertFalse($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_true_for_normal_tile(): void
+    {
+        $card = new SupportMajor();
+        $tile = new Tile(new Point(1, 0));
+
+        $this->assertTrue($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/phpunit/Dungeon/Cards/SupportMinorTest.php
+++ b/phpunit/Dungeon/Cards/SupportMinorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\SupportMinor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class SupportMinorTest extends DungeonTest
+{
+    #[Test]
+    public function interact_with_tile_marks_tile_as_supported(): void
+    {
+        $card = new SupportMinor();
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertTrue($tile->isSupported);
+        $this->assertSame(9, $card->count);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function interact_with_tile_unsets_active_card_when_count_reaches_zero(): void
+    {
+        $card = new SupportMinor();
+        $card->count = 1;
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertSame(0, $card->count);
+        $this->assertNull($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_false_for_trapped_tile(): void
+    {
+        $card = new SupportMinor();
+        $tile = new Tile(new Point(1, 0), isTrapped: true);
+
+        $this->assertFalse($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_true_for_normal_tile(): void
+    {
+        $card = new SupportMinor();
+        $tile = new Tile(new Point(1, 0));
+
+        $this->assertTrue($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/phpunit/Dungeon/Cards/TokenTest.php
+++ b/phpunit/Dungeon/Cards/TokenTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\Token;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class TokenTest extends DungeonTest
+{
+    #[Test]
+    public function play_does_nothing(): void
+    {
+        $card = new Token();
+
+        $card->play($this->dungeon);
+
+        // Token is a META card — it grants a token when purchased from the shop;
+        // playing it in-game has no effect.
+        $this->assertTrue($this->dungeon->hasEnded === false);
+    }
+}

--- a/phpunit/Dungeon/Cards/TrapDisarmMajorTest.php
+++ b/phpunit/Dungeon/Cards/TrapDisarmMajorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\TrapDisarmMajor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class TrapDisarmMajorTest extends DungeonTest
+{
+    #[Test]
+    public function interact_with_tile_removes_trap(): void
+    {
+        $card = new TrapDisarmMajor();
+        $tile = new Tile(new Point(1, 0), isTrapped: true);
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertFalse($tile->isTrapped);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function interact_with_tile_unsets_active_card_after_three_uses(): void
+    {
+        $card = new TrapDisarmMajor();
+        $this->dungeon->setActiveCard($card);
+
+        for ($i = 0; $i < 3; $i++) {
+            $tile = new Tile(new Point($i + 1, 0), isTrapped: true);
+            $this->dungeon->addTile($tile);
+            $card->interactWithTile($this->dungeon, $tile);
+        }
+
+        $this->assertNull($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    #[Test]
+    public function interact_with_tile_does_not_unset_card_before_three_uses(): void
+    {
+        $card = new TrapDisarmMajor();
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0), isTrapped: true);
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertNotNull($this->dungeon->activeCard);
+        $this->eventBus->assertNotDispatched(ActiveCardUnset::class);
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_true_for_trapped_tile(): void
+    {
+        $card = new TrapDisarmMajor();
+        $tile = new Tile(new Point(1, 0), isTrapped: true);
+
+        $this->assertTrue($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_false_for_non_trapped_tile(): void
+    {
+        $card = new TrapDisarmMajor();
+        $tile = new Tile(new Point(1, 0));
+
+        $this->assertFalse($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/phpunit/Dungeon/Cards/TrapDisarmMinorTest.php
+++ b/phpunit/Dungeon/Cards/TrapDisarmMinorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\TrapDisarmMinor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class TrapDisarmMinorTest extends DungeonTest
+{
+    #[Test]
+    public function interact_with_tile_removes_trap_and_unsets_active_card(): void
+    {
+        $card = new TrapDisarmMinor();
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0), isTrapped: true);
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        $this->assertFalse($tile->isTrapped);
+        $this->assertNull($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_true_for_trapped_tile(): void
+    {
+        $card = new TrapDisarmMinor();
+        $tile = new Tile(new Point(1, 0), isTrapped: true);
+
+        $this->assertTrue($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    #[Test]
+    public function can_interact_with_tile_returns_false_for_non_trapped_tile(): void
+    {
+        $card = new TrapDisarmMinor();
+        $tile = new Tile(new Point(1, 0));
+
+        $this->assertFalse($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/phpunit/Dungeon/Cards/UpperHandMajorTest.php
+++ b/phpunit/Dungeon/Cards/UpperHandMajorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\UpperHandMajor;
+use App\Dungeon\Events\DwellerDespawned;
+use App\Dungeon\Events\DwellerSpawned;
+use App\Dungeon\Point;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class UpperHandMajorTest extends DungeonTest
+{
+    #[Test]
+    public function play_despawns_all_visible_dwellers(): void
+    {
+        $this->dungeon->dwellers = [];
+        // Spawn within visibility radius (default 5, player at origin)
+        $this->dungeon->spawnDweller(new Point(2, 0));
+        $this->dungeon->spawnDweller(new Point(3, 0));
+        $card = new UpperHandMajor();
+
+        $card->play($this->dungeon);
+
+        $this->assertNull($this->dungeon->getDweller(new Point(2, 0)));
+        $this->assertNull($this->dungeon->getDweller(new Point(3, 0)));
+        $this->eventBus->assertDispatched(DwellerDespawned::class);
+    }
+
+    #[Test]
+    public function play_spawns_a_new_dweller_for_each_despawned(): void
+    {
+        $this->dungeon->dwellers = [];
+        $this->dungeon->spawnDweller(new Point(2, 0));
+        $this->dungeon->spawnDweller(new Point(3, 0));
+        $dwellerCountBefore = iterator_count($this->dungeon->loopDwellers());
+        $card = new UpperHandMajor();
+
+        $card->play($this->dungeon);
+
+        $this->assertSame($dwellerCountBefore, iterator_count($this->dungeon->loopDwellers()));
+        $this->eventBus->assertDispatched(DwellerSpawned::class);
+    }
+
+    #[Test]
+    public function can_play_returns_true_when_visible_dwellers_exist(): void
+    {
+        $this->dungeon->dwellers = [];
+        $this->dungeon->spawnDweller(new Point(2, 0));
+        $card = new UpperHandMajor();
+
+        $this->assertTrue($card->canPlay($this->dungeon));
+    }
+
+    #[Test]
+    public function can_play_returns_false_when_no_visible_dwellers(): void
+    {
+        $this->dungeon->dwellers = [];
+        $card = new UpperHandMajor();
+
+        $this->assertFalse($card->canPlay($this->dungeon));
+    }
+}

--- a/phpunit/Dungeon/Cards/UpperHandMinorTest.php
+++ b/phpunit/Dungeon/Cards/UpperHandMinorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\UpperHandMinor;
+use App\Dungeon\Events\DwellerDespawned;
+use App\Dungeon\Events\DwellerSpawned;
+use App\Dungeon\Point;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class UpperHandMinorTest extends DungeonTest
+{
+    #[Test]
+    public function play_despawns_one_visible_dweller(): void
+    {
+        $this->dungeon->dwellers = [];
+        $this->dungeon->spawnDweller(new Point(2, 0));
+        $card = new UpperHandMinor();
+
+        $card->play($this->dungeon);
+
+        // One despawned, one spawned — total stays at 1
+        $this->assertSame(1, iterator_count($this->dungeon->loopDwellers()));
+        $this->eventBus->assertDispatched(DwellerDespawned::class);
+    }
+
+    #[Test]
+    public function play_spawns_a_new_dweller(): void
+    {
+        $this->dungeon->dwellers = [];
+        $this->dungeon->spawnDweller(new Point(2, 0));
+        $card = new UpperHandMinor();
+
+        $card->play($this->dungeon);
+
+        // Total count stays the same: 1 despawned, 1 spawned
+        $this->assertSame(1, iterator_count($this->dungeon->loopDwellers()));
+        $this->eventBus->assertDispatched(DwellerSpawned::class);
+    }
+
+    #[Test]
+    public function can_play_returns_true_when_visible_dwellers_exist(): void
+    {
+        $this->dungeon->dwellers = [];
+        $this->dungeon->spawnDweller(new Point(2, 0));
+        $card = new UpperHandMinor();
+
+        $this->assertTrue($card->canPlay($this->dungeon));
+    }
+
+    #[Test]
+    public function can_play_returns_false_when_no_visible_dwellers(): void
+    {
+        $this->dungeon->dwellers = [];
+        $card = new UpperHandMinor();
+
+        $this->assertFalse($card->canPlay($this->dungeon));
+    }
+}

--- a/phpunit/Dungeon/Cards/VictoryPointTest.php
+++ b/phpunit/Dungeon/Cards/VictoryPointTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\Cards;
+
+use App\Dungeon\Cards\VictoryPoint;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PHPUnit\Dungeon\DungeonTest;
+
+final class VictoryPointTest extends DungeonTest
+{
+    #[Test]
+    public function play_does_nothing(): void
+    {
+        $card = new VictoryPoint();
+
+        $card->play($this->dungeon);
+
+        // VictoryPoint is a META card — it grants a VP when purchased from the shop;
+        // playing it in-game has no effect.
+        $this->assertTrue($this->dungeon->hasEnded === false);
+    }
+}

--- a/phpunit/Dungeon/DeckValidators/BreakthroughDeckValidatorTest.php
+++ b/phpunit/Dungeon/DeckValidators/BreakthroughDeckValidatorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\BreakthroughMajor;
+use App\Dungeon\Cards\BreakthroughMinor;
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\DeckValidators\BreakthroughDeckValidator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Arr\ImmutableArray;
+
+final class BreakthroughDeckValidatorTest extends TestCase
+{
+    #[Test]
+    public function validate_returns_null_for_non_breakthrough_card(): void
+    {
+        $validator = new BreakthroughDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new BreakthroughMinor()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_null_when_deck_has_fewer_than_5_breakthrough_cards(): void
+    {
+        $validator = new BreakthroughDeckValidator();
+        $deck = new ImmutableArray([
+            new BreakthroughMinor(),
+            new BreakthroughMajor(),
+            new BreakthroughMinor(),
+            new BreakthroughMajor(),
+        ]);
+
+        $result = $validator->validate(new BreakthroughMinor(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_failure_when_deck_already_has_5_breakthrough_cards(): void
+    {
+        $validator = new BreakthroughDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new BreakthroughMinor()));
+
+        $result = $validator->validate(new BreakthroughMajor(), $deck);
+
+        $this->assertNotNull($result);
+        $this->assertSame('You can only have 5 breakthrough cards in your deck', $result->message);
+    }
+}

--- a/phpunit/Dungeon/DeckValidators/ClarityDeckValidatorTest.php
+++ b/phpunit/Dungeon/DeckValidators/ClarityDeckValidatorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\Clarity;
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\DeckValidators\ClarityDeckValidator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Arr\ImmutableArray;
+
+final class ClarityDeckValidatorTest extends TestCase
+{
+    #[Test]
+    public function validate_returns_null_for_non_clarity_card(): void
+    {
+        $validator = new ClarityDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 3, new Clarity()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_null_when_deck_has_fewer_than_3_clarity_cards(): void
+    {
+        $validator = new ClarityDeckValidator();
+        $deck = new ImmutableArray([new Clarity(), new Clarity()]);
+
+        $result = $validator->validate(new Clarity(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_failure_when_deck_already_has_3_clarity_cards(): void
+    {
+        $validator = new ClarityDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 3, new Clarity()));
+
+        $result = $validator->validate(new Clarity(), $deck);
+
+        $this->assertNotNull($result);
+        $this->assertSame('You can only have 3 clarity cards in your deck', $result->message);
+    }
+}

--- a/phpunit/Dungeon/DeckValidators/CompoundDeckValidatorTest.php
+++ b/phpunit/Dungeon/DeckValidators/CompoundDeckValidatorTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\DeckValidators;
+
+use App\Dungeon\Card;
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\DeckValidationFailed;
+use App\Dungeon\DeckValidator;
+use App\Dungeon\DeckValidators\CompoundDeckValidator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Arr\ImmutableArray;
+
+final class CompoundDeckValidatorTest extends TestCase
+{
+    #[Test]
+    public function validate_returns_null_when_all_validators_pass(): void
+    {
+        $compound = new CompoundDeckValidator();
+        $compound->addValidator(new class implements DeckValidator {
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                return null;
+            }
+        });
+        $compound->addValidator(new class implements DeckValidator {
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                return null;
+            }
+        });
+
+        $result = $compound->validate(new HealMinor(), new ImmutableArray([]));
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_first_failure(): void
+    {
+        $compound = new CompoundDeckValidator();
+        $compound->addValidator(new class implements DeckValidator {
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                return new DeckValidationFailed('First failure');
+            }
+        });
+        $compound->addValidator(new class implements DeckValidator {
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                return new DeckValidationFailed('Second failure');
+            }
+        });
+
+        $result = $compound->validate(new HealMinor(), new ImmutableArray([]));
+
+        $this->assertNotNull($result);
+        $this->assertSame('First failure', $result->message);
+    }
+
+    #[Test]
+    public function validate_stops_at_first_failure_and_skips_remaining_validators(): void
+    {
+        $compound = new CompoundDeckValidator();
+        $compound->addValidator(new class implements DeckValidator {
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                return null;
+            }
+        });
+        $compound->addValidator(new class implements DeckValidator {
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                return new DeckValidationFailed('Blocking failure');
+            }
+        });
+        $spy = new class implements DeckValidator {
+            public bool $reached = false;
+
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                $this->reached = true;
+
+                return null;
+            }
+        };
+        $compound->addValidator($spy);
+
+        $compound->validate(new HealMinor(), new ImmutableArray([]));
+
+        $this->assertFalse($spy->reached);
+    }
+}

--- a/phpunit/Dungeon/DeckValidators/DeckSizeValidatorTest.php
+++ b/phpunit/Dungeon/DeckValidators/DeckSizeValidatorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\DeckValidators\DeckSizeValidator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Arr\ImmutableArray;
+
+final class DeckSizeValidatorTest extends TestCase
+{
+    #[Test]
+    public function validate_returns_null_when_deck_has_fewer_than_20_cards(): void
+    {
+        $validator = new DeckSizeValidator();
+        $deck = new ImmutableArray(array_fill(0, 19, new HealMinor()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_failure_when_deck_has_20_cards(): void
+    {
+        $validator = new DeckSizeValidator();
+        $deck = new ImmutableArray(array_fill(0, 20, new HealMinor()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        $this->assertNotNull($result);
+        $this->assertSame('Your deck is full', $result->message);
+    }
+}

--- a/phpunit/Dungeon/DeckValidators/LocateDeckValidatorTest.php
+++ b/phpunit/Dungeon/DeckValidators/LocateDeckValidatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\Cards\LocateHealthAltar;
+use App\Dungeon\Cards\LocateManaAltar;
+use App\Dungeon\Cards\LocateStabilityAltar;
+use App\Dungeon\DeckValidators\LocateDeckValidator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Arr\ImmutableArray;
+
+final class LocateDeckValidatorTest extends TestCase
+{
+    #[Test]
+    public function validate_returns_null_for_non_locate_card(): void
+    {
+        $validator = new LocateDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 3, new LocateHealthAltar()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_null_when_deck_has_fewer_than_3_locate_cards(): void
+    {
+        $validator = new LocateDeckValidator();
+        $deck = new ImmutableArray([
+            new LocateHealthAltar(),
+            new LocateManaAltar(),
+        ]);
+
+        $result = $validator->validate(new LocateStabilityAltar(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_failure_when_deck_already_has_3_locate_cards(): void
+    {
+        $validator = new LocateDeckValidator();
+        $deck = new ImmutableArray([
+            new LocateHealthAltar(),
+            new LocateManaAltar(),
+            new LocateStabilityAltar(),
+        ]);
+
+        $result = $validator->validate(new LocateHealthAltar(), $deck);
+
+        $this->assertNotNull($result);
+        $this->assertSame('You can only have 3 locate cards in your deck', $result->message);
+    }
+}

--- a/phpunit/Dungeon/DeckValidators/PermanentCardDeckValidatorTest.php
+++ b/phpunit/Dungeon/DeckValidators/PermanentCardDeckValidatorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\ChestplateMajorPermanent;
+use App\Dungeon\Cards\ChestplateMinorPermanent;
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\Cards\ManaPerMovePermanent;
+use App\Dungeon\DeckValidators\PermanentCardDeckValidator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Arr\ImmutableArray;
+
+final class PermanentCardDeckValidatorTest extends TestCase
+{
+    #[Test]
+    public function validate_returns_null_for_non_permanent_card(): void
+    {
+        $validator = new PermanentCardDeckValidator();
+        $deck = new ImmutableArray([
+            new ChestplateMinorPermanent(),
+            new ChestplateMinorPermanent(),
+            new ChestplateMinorPermanent(),
+        ]);
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_null_when_deck_has_fewer_than_3_permanent_cards(): void
+    {
+        $validator = new PermanentCardDeckValidator();
+        $deck = new ImmutableArray([
+            new ChestplateMinorPermanent(),
+            new ChestplateMajorPermanent(),
+        ]);
+
+        $result = $validator->validate(new ManaPerMovePermanent(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_failure_when_deck_already_has_3_permanent_cards(): void
+    {
+        $validator = new PermanentCardDeckValidator();
+        $deck = new ImmutableArray([
+            new ChestplateMinorPermanent(),
+            new ChestplateMajorPermanent(),
+            new ManaPerMovePermanent(),
+        ]);
+
+        $result = $validator->validate(new ChestplateMinorPermanent(), $deck);
+
+        $this->assertNotNull($result);
+        $this->assertSame('You can only have 3 permanent cards in your deck', $result->message);
+    }
+}

--- a/phpunit/Dungeon/DeckValidators/RumbleDeckValidatorTest.php
+++ b/phpunit/Dungeon/DeckValidators/RumbleDeckValidatorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\Cards\RumbleMajor;
+use App\Dungeon\Cards\RumbleMinor;
+use App\Dungeon\DeckValidators\RumbleDeckValidator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Arr\ImmutableArray;
+
+final class RumbleDeckValidatorTest extends TestCase
+{
+    #[Test]
+    public function validate_returns_null_for_non_rumble_card(): void
+    {
+        $validator = new RumbleDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new RumbleMinor()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_null_for_rumble_major(): void
+    {
+        // RumbleDeckValidator only checks RumbleMinor; RumbleMajor is not restricted
+        $validator = new RumbleDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new RumbleMinor()));
+
+        $result = $validator->validate(new RumbleMajor(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_null_when_deck_has_fewer_than_5_rumble_minor_cards(): void
+    {
+        $validator = new RumbleDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 4, new RumbleMinor()));
+
+        $result = $validator->validate(new RumbleMinor(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_failure_when_deck_already_has_5_rumble_minor_cards(): void
+    {
+        $validator = new RumbleDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new RumbleMinor()));
+
+        $result = $validator->validate(new RumbleMinor(), $deck);
+
+        $this->assertNotNull($result);
+        $this->assertSame('You can only have 5 rumble cards in your deck', $result->message);
+    }
+}

--- a/phpunit/Dungeon/DeckValidators/StabilityDeckValidatorTest.php
+++ b/phpunit/Dungeon/DeckValidators/StabilityDeckValidatorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\Cards\StabilityMajor;
+use App\Dungeon\Cards\StabilityMinor;
+use App\Dungeon\DeckValidators\StabilityDeckValidator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Arr\ImmutableArray;
+
+final class StabilityDeckValidatorTest extends TestCase
+{
+    #[Test]
+    public function validate_returns_null_for_non_stability_card(): void
+    {
+        $validator = new StabilityDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 7, new StabilityMinor()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_null_when_deck_has_fewer_than_7_stability_cards(): void
+    {
+        $validator = new StabilityDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 6, new StabilityMinor()));
+
+        $result = $validator->validate(new StabilityMajor(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_failure_when_deck_already_has_7_stability_cards(): void
+    {
+        $validator = new StabilityDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 7, new StabilityMinor()));
+
+        $result = $validator->validate(new StabilityMajor(), $deck);
+
+        $this->assertNotNull($result);
+        $this->assertSame('You can only have 7 stability cards in your deck', $result->message);
+    }
+}

--- a/phpunit/Dungeon/DeckValidators/SupportDeckValidatorTest.php
+++ b/phpunit/Dungeon/DeckValidators/SupportDeckValidatorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\Cards\SupportMajor;
+use App\Dungeon\Cards\SupportMinor;
+use App\Dungeon\DeckValidators\SupportDeckValidator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Arr\ImmutableArray;
+
+final class SupportDeckValidatorTest extends TestCase
+{
+    #[Test]
+    public function validate_returns_null_for_non_support_card(): void
+    {
+        $validator = new SupportDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new SupportMinor()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_null_when_deck_has_fewer_than_5_support_cards(): void
+    {
+        $validator = new SupportDeckValidator();
+        $deck = new ImmutableArray([
+            new SupportMinor(),
+            new SupportMajor(),
+            new SupportMinor(),
+            new SupportMajor(),
+        ]);
+
+        $result = $validator->validate(new SupportMinor(), $deck);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function validate_returns_failure_when_deck_already_has_5_support_cards(): void
+    {
+        $validator = new SupportDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new SupportMinor()));
+
+        $result = $validator->validate(new SupportMajor(), $deck);
+
+        $this->assertNotNull($result);
+        $this->assertSame('You can only have 5 support cards in your deck', $result->message);
+    }
+}

--- a/phpunit/Dungeon/DungeonActionsTest.php
+++ b/phpunit/Dungeon/DungeonActionsTest.php
@@ -1,0 +1,1497 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon;
+
+use App\Dungeon\Cards\BeaconMinor;
+use App\Dungeon\Direction;
+use App\Dungeon\Events\ActiveCardSet;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\ArtifactCollected;
+use App\Dungeon\Events\ArtifactSpawned;
+use App\Dungeon\Events\CardDrawn;
+use App\Dungeon\Events\CardPlayed;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\DwellerDespawned;
+use App\Dungeon\Events\DwellerMoved;
+use App\Dungeon\Events\DwellerSpawned;
+use App\Dungeon\Events\DwellerUpdated;
+use App\Dungeon\Events\LakeDiscovered;
+use App\Dungeon\Events\PassiveCardSet;
+use App\Dungeon\Events\PassiveCardUnset;
+use App\Dungeon\Events\PermanentCardAdded;
+use App\Dungeon\Events\PlayerCoinsIncreased;
+use App\Dungeon\Events\PlayerExited;
+use App\Dungeon\Events\PlayerHealthDecreased;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerManaDecreased;
+use App\Dungeon\Events\PlayerManaIncreased;
+use App\Dungeon\Events\PlayerMaxHealthIncreased;
+use App\Dungeon\Events\PlayerMaxManaIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Events\PlayerResigned;
+use App\Dungeon\Events\PlayerShardsIncreased;
+use App\Dungeon\Events\PlayerStabilityDecreased;
+use App\Dungeon\Events\PlayerStabilityIncreased;
+use App\Dungeon\Events\PlayerVictoryPointsIncreased;
+use App\Dungeon\Events\RelicCollected;
+use App\Dungeon\Events\TileCoinsAdded;
+use App\Dungeon\Events\TileCoinsCollected;
+use App\Dungeon\Events\TileCollapsed;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Events\VisibilityChanged;
+use App\Dungeon\Lake;
+use App\Dungeon\LakePoint;
+use App\Dungeon\Listeners\PlayerMovementListener;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use PHPUnit\Framework\Attributes\Test;
+
+final class DungeonActionsTest extends DungeonTest
+{
+    // -------------------------------------------------------------------------
+    // generateTile
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function generate_tile_adds_new_tile(): void
+    {
+        $point = new Point(x: 1, y: 1);
+
+        $this->dungeon->generateTile(from: null, to: $point);
+
+        $this->assertNotNull($this->dungeon->tryTile($point));
+
+        $this->eventBus->assertDispatched(TileGenerated::class, function (TileGenerated $event) use ($point) {
+            $this->assertTrue($event->tile->point->equals($point));
+        });
+    }
+
+    #[Test]
+    public function generate_tile_does_not_overwrite_existing_tile(): void
+    {
+        $point = new Point(0, 0); // origin tile already exists
+
+        $tileCountBefore = $this->dungeon->tileCount();
+
+        $this->dungeon->generateTile(from: null, to: $point);
+
+        $this->assertSame($tileCountBefore, $this->dungeon->tileCount());
+        $this->eventBus->assertNotDispatched(TileGenerated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // move
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function move_updates_player_position(): void
+    {
+        $this->dungeon->move(Direction::RIGHT);
+
+        $this->assertTrue($this->dungeon->playerPosition->equals(new Point(1, 0)));
+
+        $this->eventBus->assertDispatched(PlayerMoved::class, function (PlayerMoved $event) {
+            $this->assertTrue($event->from->equals(new Point(0, 0)));
+            $this->assertTrue($event->to->equals(new Point(1, 0)));
+        });
+    }
+
+    #[Test]
+    public function move_generates_new_tile_when_no_tile_exists_at_destination(): void
+    {
+        $this->assertNull($this->dungeon->tryTile(new Point(1, 0)));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        $this->assertNotNull($this->dungeon->tryTile(new Point(1, 0)));
+        $this->eventBus->assertDispatched(TileGenerated::class);
+    }
+
+    #[Test]
+    public function move_does_not_move_when_current_tile_has_no_opening_in_that_direction(): void
+    {
+        $this->dungeon->addTile(new Tile(new Point(0, 0), directions: [Direction::TOP, Direction::BOTTOM], isOrigin: true));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        $this->assertTrue($this->dungeon->playerPosition->equals(new Point(0, 0)));
+        $this->eventBus->assertNotDispatched(PlayerMoved::class);
+    }
+
+    #[Test]
+    public function move_does_not_move_into_collapsed_tile(): void
+    {
+        $this->dungeon->addTile(new Tile(new Point(1, 0), isCollapsed: true));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        $this->assertTrue($this->dungeon->playerPosition->equals(new Point(0, 0)));
+        $this->eventBus->assertNotDispatched(PlayerMoved::class);
+    }
+
+    #[Test]
+    public function move_does_not_move_when_neighbour_tile_has_no_opening_on_its_entry_side(): void
+    {
+        $this->dungeon->addTile(new Tile(new Point(1, 0), directions: [Direction::RIGHT, Direction::TOP, Direction::BOTTOM]));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        $this->assertTrue($this->dungeon->playerPosition->equals(new Point(0, 0)));
+        $this->eventBus->assertNotDispatched(PlayerMoved::class);
+    }
+
+    #[Test]
+    public function move_does_not_move_onto_lake_tile(): void
+    {
+        $this->dungeon->addTile(new Tile(new Point(1, 0), isLake: true));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        $this->assertTrue($this->dungeon->playerPosition->equals(new Point(0, 0)));
+        $this->eventBus->assertNotDispatched(PlayerMoved::class);
+    }
+
+    #[Test]
+    public function move_can_move_onto_lake_tile_when_can_walk_on_water(): void
+    {
+        $this->dungeon->addTile(new Tile(new Point(1, 0), isLake: true));
+        $this->dungeon->canWalkOnWater = true;
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        $this->assertTrue($this->dungeon->playerPosition->equals(new Point(1, 0)));
+        $this->eventBus->assertDispatched(PlayerMoved::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // generateTile (lake)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function generate_tile_on_lake_point_marks_tile_as_lake(): void
+    {
+        $lakePoint = new Point(5, 5);
+        $lake = new Lake($lakePoint);
+        $lake->addLakePoint(new LakePoint($lakePoint, depth: 2));
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $lakePoint);
+
+        $tile = $this->dungeon->tryTile($lakePoint);
+        $this->assertTrue($tile->isLake);
+        $this->assertSame(2, $tile->depth);
+    }
+
+    #[Test]
+    public function generate_tile_on_lake_point_opens_all_directions(): void
+    {
+        $lakePoint = new Point(5, 5);
+        $lake = new Lake($lakePoint);
+        $lake->addLakePoint(new LakePoint($lakePoint, depth: 1));
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $lakePoint);
+
+        $tile = $this->dungeon->tryTile($lakePoint);
+        $this->assertSame(Direction::cases(), $tile->directions);
+    }
+
+    #[Test]
+    public function generate_tile_on_lake_relic_point_marks_tile_as_relic(): void
+    {
+        $lakePoint = new Point(5, 5);
+        $lake = new Lake($lakePoint);
+        $lake->addLakePoint(new LakePoint($lakePoint, depth: 3));
+        $lake->relic = $lakePoint;
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $lakePoint);
+
+        $tile = $this->dungeon->tryTile($lakePoint);
+        $this->assertTrue($tile->isLake);
+        $this->assertTrue($tile->isRelic);
+    }
+
+    #[Test]
+    public function generate_tile_on_non_relic_lake_point_does_not_mark_tile_as_relic(): void
+    {
+        $lakePoint = new Point(5, 5);
+        $relicPoint = new Point(6, 5);
+        $lake = new Lake($lakePoint);
+        $lake->addLakePoint(new LakePoint($lakePoint, depth: 3));
+        $lake->relic = $relicPoint;
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $lakePoint);
+
+        $tile = $this->dungeon->tryTile($lakePoint);
+        $this->assertFalse($tile->isRelic);
+    }
+
+    #[Test]
+    public function generate_tile_on_lake_edge_opens_all_directions(): void
+    {
+        $origin = new Point(5, 5);
+        $edgePoint = new Point(5, 4);
+        $lake = new Lake($origin);
+        $lake->addEdge($edgePoint);
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $edgePoint);
+
+        $tile = $this->dungeon->tryTile($edgePoint);
+        $this->assertFalse($tile->isLake);
+        $this->assertSame(Direction::cases(), $tile->directions);
+    }
+
+    #[Test]
+    public function generate_tile_on_lake_edge_dispatches_lake_discovered(): void
+    {
+        $origin = new Point(5, 5);
+        $edgePoint = new Point(5, 4);
+        $lake = new Lake($origin);
+        $lake->addEdge($edgePoint);
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $edgePoint);
+
+        $this->eventBus->assertDispatched(LakeDiscovered::class, function (LakeDiscovered $event) use ($edgePoint) {
+            $this->assertTrue($event->tile->point->equals($edgePoint));
+            $this->assertTrue($event->lake->isDiscovered);
+        });
+    }
+
+    #[Test]
+    public function generate_tile_on_already_discovered_lake_edge_does_not_dispatch_lake_discovered(): void
+    {
+        $origin = new Point(5, 5);
+        $edgePoint = new Point(5, 4);
+        $lake = new Lake($origin, isDiscovered: true);
+        $lake->addEdge($edgePoint);
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $edgePoint);
+
+        $this->eventBus->assertNotDispatched(LakeDiscovered::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // collectRelic
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function collect_relic_marks_tile_as_not_relic(): void
+    {
+        $tile = new Tile(new Point(1, 0), isRelic: true);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collectRelic($tile);
+
+        $this->assertFalse($tile->isRelic);
+    }
+
+    #[Test]
+    public function collect_relic_dispatches_relic_collected_event(): void
+    {
+        $tile = new Tile(new Point(1, 0), isRelic: true);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collectRelic($tile);
+
+        $this->eventBus->assertDispatched(RelicCollected::class, function (RelicCollected $event) use ($tile) {
+            $this->assertTrue($event->tile->point->equals($tile->point));
+        });
+    }
+
+    #[Test]
+    public function collect_relic_increases_coins(): void
+    {
+        $tile = new Tile(new Point(1, 0), isRelic: true);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collectRelic($tile);
+
+        $this->assertGreaterThan(0, $this->dungeon->coins);
+    }
+
+    #[Test]
+    public function collect_relic_increases_mana(): void
+    {
+        $tile = new Tile(new Point(1, 0), isRelic: true);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collectRelic($tile);
+
+        $this->assertGreaterThan(0, $this->dungeon->mana);
+    }
+
+    #[Test]
+    public function collect_relic_does_nothing_when_tile_is_not_relic(): void
+    {
+        $tile = new Tile(new Point(1, 0), isRelic: false);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collectRelic($tile);
+
+        $this->assertSame(0, $this->dungeon->coins);
+        $this->eventBus->assertNotDispatched(RelicCollected::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // addCoinsToTile
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function add_coins_to_tile(): void
+    {
+        $tile = $this->dungeon->currentTile;
+
+        $this->dungeon->addCoinsToTile($tile, 50);
+
+        $this->assertSame(50, $tile->coins);
+
+        $this->eventBus->assertDispatched(TileCoinsAdded::class, function (TileCoinsAdded $event) use ($tile) {
+            $this->assertTrue($event->tile->point->equals($tile->point));
+            $this->assertSame(50, $event->amount);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // collectCoins
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function collect_coins(): void
+    {
+        $tile = $this->dungeon->currentTile;
+        $tile->coins = 75;
+
+        $this->dungeon->collectCoins($tile);
+
+        $this->assertSame(75, $this->dungeon->coins);
+        $this->assertSame(0, $tile->coins);
+
+        $this->eventBus->assertDispatched(TileCoinsCollected::class, function (TileCoinsCollected $event) {
+            $this->assertSame(75, $event->amount);
+            $this->assertSame(75, $event->total);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseMaxMana
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function increase_max_mana(): void
+    {
+        $this->dungeon->increaseMaxMana(50);
+
+        $this->assertSame(200, $this->dungeon->maxMana);
+
+        $this->eventBus->assertDispatched(PlayerMaxManaIncreased::class, function (PlayerMaxManaIncreased $event) {
+            $this->assertSame(50, $event->amount);
+            $this->assertSame(200, $event->total);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseMana / decreaseMana
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function increase_mana(): void
+    {
+        $this->dungeon->increaseMana(30);
+
+        $this->assertSame(30, $this->dungeon->mana);
+
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class, function (PlayerManaIncreased $event) {
+            $this->assertSame(30, $event->amount);
+            $this->assertSame(30, $event->total);
+        });
+    }
+
+    #[Test]
+    public function increase_mana_is_capped_at_max_mana(): void
+    {
+        $this->dungeon->increaseMana(200); // maxMana is 150
+
+        $this->assertSame(150, $this->dungeon->mana);
+
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class, function (PlayerManaIncreased $event) {
+            $this->assertSame(150, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function increase_mana_does_nothing_when_already_at_max(): void
+    {
+        $this->dungeon->mana = 150;
+
+        $this->dungeon->increaseMana(10);
+
+        $this->assertSame(150, $this->dungeon->mana);
+        $this->eventBus->assertNotDispatched(PlayerManaIncreased::class);
+    }
+
+    #[Test]
+    public function increase_mana_includes_reason_in_event(): void
+    {
+        $this->dungeon->increaseMana(30, 'You found a mana altar (+30 mana)');
+
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class, function (PlayerManaIncreased $event) {
+            $this->assertSame('You found a mana altar (+30 mana)', $event->reason);
+        });
+    }
+
+    #[Test]
+    public function increase_mana_reason_is_null_by_default(): void
+    {
+        $this->dungeon->increaseMana(30);
+
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class, function (PlayerManaIncreased $event) {
+            $this->assertNull($event->reason);
+        });
+    }
+
+    #[Test]
+    public function decrease_mana(): void
+    {
+        $this->dungeon->mana = 100;
+
+        $this->dungeon->decreaseMana(30);
+
+        $this->assertSame(70, $this->dungeon->mana);
+
+        $this->eventBus->assertDispatched(PlayerManaDecreased::class, function (PlayerManaDecreased $event) {
+            $this->assertSame(30, $event->amount);
+            $this->assertSame(70, $event->total);
+        });
+    }
+
+    #[Test]
+    public function decrease_mana_is_clamped_at_zero(): void
+    {
+        $this->dungeon->mana = 10;
+
+        $this->dungeon->decreaseMana(50);
+
+        $this->assertSame(0, $this->dungeon->mana);
+
+        $this->eventBus->assertDispatched(PlayerManaDecreased::class, function (PlayerManaDecreased $event) {
+            $this->assertSame(10, $event->amount);
+            $this->assertSame(0, $event->total);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseCoins
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function increase_coins(): void
+    {
+        $this->dungeon->increaseCoins(100);
+
+        $this->assertSame(100, $this->dungeon->coins);
+
+        $this->eventBus->assertDispatched(PlayerCoinsIncreased::class, function (PlayerCoinsIncreased $event) {
+            $this->assertSame(100, $event->amount);
+            $this->assertSame(100, $event->total);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseMaxHealth
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function increase_max_health(): void
+    {
+        $this->dungeon->increaseMaxHealth(50);
+
+        $this->assertSame(150, $this->dungeon->maxHealth);
+
+        $this->eventBus->assertDispatched(PlayerMaxHealthIncreased::class, function (PlayerMaxHealthIncreased $event) {
+            $this->assertSame(50, $event->amount);
+            $this->assertSame(150, $event->total);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseHealth / decreaseHealth
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function increase_health(): void
+    {
+        $this->dungeon->health = 50;
+
+        $this->dungeon->increaseHealth(30);
+
+        $this->assertSame(80, $this->dungeon->health);
+
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(30, $event->amount);
+            $this->assertSame(80, $event->total);
+        });
+    }
+
+    #[Test]
+    public function increase_health_is_capped_at_max_health(): void
+    {
+        $this->dungeon->health = 80;
+
+        $this->dungeon->increaseHealth(50); // maxHealth is 100
+
+        $this->assertSame(100, $this->dungeon->health);
+
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame(20, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function increase_health_does_nothing_when_already_at_max(): void
+    {
+        $this->dungeon->increaseHealth(10); // already at 100
+
+        $this->assertSame(100, $this->dungeon->health);
+        $this->eventBus->assertNotDispatched(PlayerHealthIncreased::class);
+    }
+
+    #[Test]
+    public function increase_health_includes_reason_in_event(): void
+    {
+        $this->dungeon->health = 50;
+
+        $this->dungeon->increaseHealth(30, 'You found a health altar (+30 health)');
+
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertSame('You found a health altar (+30 health)', $event->reason);
+        });
+    }
+
+    #[Test]
+    public function increase_health_reason_is_null_by_default(): void
+    {
+        $this->dungeon->health = 50;
+
+        $this->dungeon->increaseHealth(30);
+
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            $this->assertNull($event->reason);
+        });
+    }
+
+    #[Test]
+    public function decrease_health(): void
+    {
+        $this->dungeon->decreaseHealth(30);
+
+        $this->assertSame(70, $this->dungeon->health);
+
+        $this->eventBus->assertDispatched(PlayerHealthDecreased::class, function (PlayerHealthDecreased $event) {
+            $this->assertSame(30, $event->amount);
+            $this->assertSame(70, $event->total);
+        });
+    }
+
+    #[Test]
+    public function decrease_health_is_clamped_at_zero(): void
+    {
+        $this->dungeon->health = 10;
+
+        $this->dungeon->decreaseHealth(50);
+
+        $this->assertSame(0, $this->dungeon->health);
+
+        $this->eventBus->assertDispatched(PlayerHealthDecreased::class, function (PlayerHealthDecreased $event) {
+            $this->assertSame(10, $event->amount);
+            $this->assertSame(0, $event->total);
+        });
+    }
+
+    #[Test]
+    public function decrease_health_includes_reason_in_event(): void
+    {
+        $this->dungeon->decreaseHealth(10, 'Trap triggered');
+
+        $this->eventBus->assertDispatched(PlayerHealthDecreased::class, function (PlayerHealthDecreased $event) {
+            $this->assertSame('Trap triggered', $event->reason);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // decreaseStability / increaseStability
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function decrease_stability(): void
+    {
+        $this->dungeon->decreaseStability(20);
+
+        $this->assertSame(80, $this->dungeon->stability);
+
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            $this->assertSame(20, $event->amount);
+            $this->assertSame(80, $event->total);
+        });
+    }
+
+    #[Test]
+    public function decrease_stability_is_clamped_at_zero(): void
+    {
+        $this->dungeon->stability = 10;
+
+        $this->dungeon->decreaseStability(50);
+
+        $this->assertSame(0, $this->dungeon->stability);
+
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            $this->assertSame(10, $event->amount);
+            $this->assertSame(0, $event->total);
+        });
+    }
+
+    #[Test]
+    public function increase_stability(): void
+    {
+        $this->dungeon->stability = 50;
+
+        $this->dungeon->increaseStability(30);
+
+        $this->assertSame(80, $this->dungeon->stability);
+
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            $this->assertSame(30, $event->amount);
+            $this->assertSame(80, $event->total);
+        });
+    }
+
+    #[Test]
+    public function increase_stability_is_capped_at_max_stability(): void
+    {
+        $this->dungeon->stability = 80;
+
+        $this->dungeon->increaseStability(50); // maxStability is 100
+
+        $this->assertSame(100, $this->dungeon->stability);
+
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            $this->assertSame(20, $event->amount);
+        });
+    }
+
+    #[Test]
+    public function increase_stability_does_nothing_when_already_at_max(): void
+    {
+        $this->dungeon->increaseStability(10); // already at 100
+
+        $this->assertSame(100, $this->dungeon->stability);
+        $this->eventBus->assertNotDispatched(PlayerStabilityIncreased::class);
+    }
+
+    #[Test]
+    public function increase_stability_includes_reason_in_event(): void
+    {
+        $this->dungeon->stability = 50;
+
+        $this->dungeon->increaseStability(30, 'You found a stability altar (+30 stability)');
+
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            $this->assertSame('You found a stability altar (+30 stability)', $event->reason);
+        });
+    }
+
+    #[Test]
+    public function increase_stability_reason_is_null_by_default(): void
+    {
+        $this->dungeon->stability = 50;
+
+        $this->dungeon->increaseStability(30);
+
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            $this->assertNull($event->reason);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // collapseTile
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function collapse_tile(): void
+    {
+        $tile = new Tile(new Point(5, 5));
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collapseTile($tile);
+
+        $this->assertTrue($tile->isCollapsed);
+
+        $this->eventBus->assertDispatched(TileCollapsed::class, function (TileCollapsed $event) use ($tile) {
+            $this->assertTrue($event->tile->point->equals($tile->point));
+        });
+    }
+
+    #[Test]
+    public function collapse_tile_does_not_collapse_origin_tile(): void
+    {
+        $originTile = $this->dungeon->currentTile;
+
+        $this->dungeon->collapseTile($originTile);
+
+        $this->assertFalse($originTile->isCollapsed);
+        $this->eventBus->assertNotDispatched(TileCollapsed::class);
+    }
+
+    #[Test]
+    public function collapse_tile_does_not_collapse_already_collapsed_tile(): void
+    {
+        $tile = new Tile(new Point(5, 5), isCollapsed: true);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collapseTile($tile);
+
+        $this->eventBus->assertNotDispatched(TileCollapsed::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // playCard
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function play_card(): void
+    {
+        $card = new BeaconMinor();
+        $this->dungeon->hand[$card->id] = $card;
+        $this->dungeon->mana = 100;
+
+        $this->dungeon->playCard($card->id);
+
+        $this->assertArrayNotHasKey($card->id, $this->dungeon->hand);
+
+        $this->eventBus->assertDispatched(CardPlayed::class, function (CardPlayed $event) use ($card) {
+            $this->assertSame($card->id, $event->card->id);
+        });
+    }
+
+    #[Test]
+    public function play_card_deducts_mana(): void
+    {
+        $card = new BeaconMinor(); // costs 75 mana
+        $this->dungeon->hand[$card->id] = $card;
+        $this->dungeon->mana = 100;
+
+        $this->dungeon->playCard($card->id);
+
+        $this->assertSame(25, $this->dungeon->mana);
+    }
+
+    #[Test]
+    public function play_card_does_nothing_when_card_not_in_hand(): void
+    {
+        $this->dungeon->playCard('non-existent-card-id');
+
+        $this->eventBus->assertNotDispatched(CardPlayed::class);
+    }
+
+    #[Test]
+    public function play_card_does_nothing_when_not_enough_mana(): void
+    {
+        $card = new BeaconMinor(); // costs 75 mana
+        $this->dungeon->hand[$card->id] = $card;
+        $this->dungeon->mana = 10;
+
+        $this->dungeon->playCard($card->id);
+
+        $this->assertArrayHasKey($card->id, $this->dungeon->hand);
+        $this->eventBus->assertNotDispatched(CardPlayed::class);
+    }
+
+    #[Test]
+    public function play_card_does_nothing_when_passive_slot_is_already_occupied(): void
+    {
+        $card = new BeaconMinor(); // Type::PASSIVE
+        $this->dungeon->hand[$card->id] = $card;
+        $this->dungeon->mana = 150;
+        $this->dungeon->passiveCard = new BeaconMinor();
+
+        $this->dungeon->playCard($card->id);
+
+        $this->assertArrayHasKey($card->id, $this->dungeon->hand);
+        $this->eventBus->assertNotDispatched(CardPlayed::class);
+    }
+
+    #[Test]
+    public function play_card_does_nothing_when_active_slot_is_already_occupied(): void
+    {
+        // TODO: requires a concrete active card implementation (Type::ACTIVE)
+        $this->markTestSkipped('Requires a concrete active card implementation');
+    }
+
+    // -------------------------------------------------------------------------
+    // drawCard
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function draw_card(): void
+    {
+        $card = new BeaconMinor();
+        $this->dungeon->deck[$card->id] = $card;
+        $this->dungeon->hand = [];
+
+        $this->dungeon->drawCard();
+
+        $this->assertArrayHasKey($card->id, $this->dungeon->hand);
+        $this->assertArrayNotHasKey($card->id, $this->dungeon->deck);
+
+        $this->eventBus->assertDispatched(CardDrawn::class);
+    }
+
+    #[Test]
+    public function draw_card_does_nothing_when_hand_is_full(): void
+    {
+        for ($i = 0; $i < $this->dungeon->maxHandCount; $i++) {
+            $card = new BeaconMinor();
+            $this->dungeon->hand[$card->id] = $card;
+        }
+
+        $extra = new BeaconMinor();
+        $this->dungeon->deck[$extra->id] = $extra;
+
+        $this->dungeon->drawCard();
+
+        $this->assertArrayNotHasKey($extra->id, $this->dungeon->hand);
+        $this->eventBus->assertNotDispatched(CardDrawn::class);
+    }
+
+    #[Test]
+    public function draw_card_does_nothing_when_deck_is_empty(): void
+    {
+        $this->dungeon->deck = [];
+        $this->dungeon->hand = [];
+
+        $this->dungeon->drawCard();
+
+        $this->assertEmpty($this->dungeon->hand);
+        $this->eventBus->assertNotDispatched(CardDrawn::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // setPassiveCard / unsetPassiveCard
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function set_passive_card(): void
+    {
+        $card = new BeaconMinor();
+
+        $this->dungeon->setPassiveCard($card);
+
+        $this->assertSame($card, $this->dungeon->passiveCard);
+
+        $this->eventBus->assertDispatched(PassiveCardSet::class, function (PassiveCardSet $event) use ($card) {
+            $this->assertSame($card->id, $event->card->id);
+        });
+    }
+
+    #[Test]
+    public function unset_passive_card(): void
+    {
+        $this->dungeon->passiveCard = new BeaconMinor();
+
+        $this->dungeon->unsetPassiveCard();
+
+        $this->assertNull($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PassiveCardUnset::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // setActiveCard / unsetActiveCard
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function set_active_card(): void
+    {
+        $card = new BeaconMinor();
+
+        $this->dungeon->setActiveCard($card);
+
+        $this->assertSame($card, $this->dungeon->activeCard);
+
+        $this->eventBus->assertDispatched(ActiveCardSet::class, function (ActiveCardSet $event) use ($card) {
+            $this->assertSame($card->id, $event->card->id);
+        });
+    }
+
+    #[Test]
+    public function unset_active_card(): void
+    {
+        $this->dungeon->activeCard = new BeaconMinor();
+
+        $this->dungeon->unsetActiveCard();
+
+        $this->assertNull($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // addPermanentCard
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function add_permanent_card(): void
+    {
+        $card = new BeaconMinor();
+
+        $this->dungeon->addPermanentCard($card);
+
+        $this->assertArrayHasKey($card->id, $this->dungeon->permanentCards);
+
+        $this->eventBus->assertDispatched(PermanentCardAdded::class, function (PermanentCardAdded $event) use ($card) {
+            $this->assertSame($card->id, $event->card->id);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // notifyCards
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function notify_cards(): void
+    {
+        // TODO: requires a PassiveCard implementation and a DungeonEvent; verify handle() is called on active/passive/permanent cards
+        $this->markTestSkipped('Requires a PassiveCard implementation and a DungeonEvent');
+    }
+
+    // -------------------------------------------------------------------------
+    // interactWithTile
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function interact_with_tile(): void
+    {
+        // TODO: requires a concrete ActiveCard implementation
+        $this->markTestSkipped('Requires a concrete active card implementation');
+    }
+
+    // -------------------------------------------------------------------------
+    // removeTileCollapse
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function remove_tile_collapse(): void
+    {
+        $tile = new Tile(new Point(5, 5), isCollapsed: true);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->removeTileCollapse($tile);
+
+        $this->assertFalse($tile->isCollapsed);
+
+        $this->eventBus->assertDispatched(TileUpdated::class, function (TileUpdated $event) use ($tile) {
+            $this->assertTrue($event->tile->point->equals($tile->point));
+        });
+    }
+
+    #[Test]
+    public function remove_tile_collapse_does_nothing_when_tile_is_not_collapsed(): void
+    {
+        $tile = new Tile(new Point(5, 5));
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->removeTileCollapse($tile);
+
+        $this->eventBus->assertNotDispatched(TileUpdated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // removeTileWalls
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function remove_tile_walls_opens_all_directions(): void
+    {
+        $tile = new Tile(new Point(5, 5), directions: [Direction::TOP]);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->removeTileWalls($tile);
+
+        $this->assertEqualsCanonicalizing(Direction::cases(), $tile->directions);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // spawnDweller / despawnDweller / moveDweller
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function spawn_dweller(): void
+    {
+        $point = new Point(3, 3);
+
+        $this->dungeon->spawnDweller($point);
+
+        $this->assertNotNull($this->dungeon->getDweller($point));
+
+        $this->eventBus->assertDispatched(DwellerSpawned::class, function (DwellerSpawned $event) use ($point) {
+            $this->assertTrue($event->dweller->point->equals($point));
+        });
+    }
+
+    #[Test]
+    public function despawn_dweller(): void
+    {
+        $point = new Point(3, 3);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+
+        $this->dungeon->despawnDweller($dweller);
+
+        $this->assertNull($this->dungeon->getDweller($point));
+
+        $this->eventBus->assertDispatched(DwellerDespawned::class, function (DwellerDespawned $event) use ($point) {
+            $this->assertTrue($event->dweller->point->equals($point));
+        });
+    }
+
+    #[Test]
+    public function move_dweller(): void
+    {
+        $from = new Point(3, 3);
+        $to = new Point(4, 3);
+        $this->dungeon->spawnDweller($from);
+        $dweller = $this->dungeon->getDweller($from);
+
+        $this->dungeon->moveDweller($dweller, $to);
+
+        $this->assertNull($this->dungeon->getDweller($from));
+        $this->assertNotNull($this->dungeon->getDweller($to));
+
+        $this->eventBus->assertDispatched(DwellerMoved::class, function (DwellerMoved $event) use ($from, $to) {
+            $this->assertTrue($event->from->equals($from));
+            $this->assertTrue($event->to->equals($to));
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // showDweller / hideDweller
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function show_dweller(): void
+    {
+        $point = new Point(3, 3);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $this->dungeon->showDweller($dweller);
+
+        $this->assertTrue($dweller->isVisible);
+        $this->eventBus->assertDispatched(DwellerUpdated::class);
+    }
+
+    #[Test]
+    public function show_dweller_does_nothing_when_already_visible(): void
+    {
+        $point = new Point(3, 3);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = true;
+
+        $this->dungeon->showDweller($dweller);
+
+        $this->eventBus->assertNotDispatched(DwellerUpdated::class);
+    }
+
+    #[Test]
+    public function hide_dweller(): void
+    {
+        $point = new Point(3, 3);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = true;
+
+        $this->dungeon->hideDweller($dweller);
+
+        $this->assertFalse($dweller->isVisible);
+        $this->eventBus->assertDispatched(DwellerUpdated::class);
+    }
+
+    #[Test]
+    public function hide_dweller_does_nothing_when_already_hidden(): void
+    {
+        $point = new Point(3, 3);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $this->dungeon->hideDweller($dweller);
+
+        $this->eventBus->assertNotDispatched(DwellerUpdated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // changeVisibility
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function change_visibility(): void
+    {
+        $this->dungeon->changeVisibility(10);
+
+        $this->assertSame(10, $this->dungeon->visibilityRadius);
+
+        $this->eventBus->assertDispatched(VisibilityChanged::class, function (VisibilityChanged $event) {
+            $this->assertSame(10, $event->visibilityRadius);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // spawnArtifact
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function spawn_artifact(): void
+    {
+        $point = new Point(7, 7);
+
+        $this->dungeon->spawnArtifact($point);
+
+        $this->assertTrue($this->dungeon->artifactLocation->equals($point));
+
+        $this->eventBus->assertDispatched(ArtifactSpawned::class, function (ArtifactSpawned $event) use ($point) {
+            $this->assertTrue($event->point->equals($point));
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // spawnManaAltar / spawnHealthAltar / spawnStabilityAltar
+    // (these register altar locations but do not dispatch events)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function spawn_mana_altar(): void
+    {
+        $point = new Point(5, 5);
+
+        $this->dungeon->spawnManaAltar($point);
+
+        $this->assertSame($point, $this->dungeon->manaAltars[$point->x][$point->y]);
+    }
+
+    #[Test]
+    public function spawn_health_altar(): void
+    {
+        $point = new Point(5, 5);
+
+        $this->dungeon->spawnHealthAltar($point);
+
+        $this->assertSame($point, $this->dungeon->healthAltars[$point->x][$point->y]);
+    }
+
+    #[Test]
+    public function spawn_stability_altar(): void
+    {
+        $point = new Point(5, 5);
+
+        $this->dungeon->spawnStabilityAltar($point);
+
+        $this->assertSame($point, $this->dungeon->stabilityAltars[$point->x][$point->y]);
+    }
+
+    // -------------------------------------------------------------------------
+    // spawnVictoryPoint / spawnShard
+    // (these register locations but do not dispatch events)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function spawn_victory_point(): void
+    {
+        $point = new Point(5, 5);
+
+        $this->dungeon->spawnVictoryPoint($point);
+
+        $this->assertSame($point, $this->dungeon->victoryPointLocations[$point->x][$point->y]);
+    }
+
+    #[Test]
+    public function spawn_shard(): void
+    {
+        $point = new Point(5, 5);
+
+        $this->dungeon->spawnShard($point);
+
+        $this->assertSame($point, $this->dungeon->shardLocations[$point->x][$point->y]);
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseExperience (no event dispatched)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function increase_experience(): void
+    {
+        $this->dungeon->increaseExperience(100);
+
+        $this->assertSame(100, $this->dungeon->experience);
+    }
+
+    // -------------------------------------------------------------------------
+    // collectArtifact
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function collect_artifact(): void
+    {
+        $this->dungeon->artifactLocation = clone $this->dungeon->playerPosition;
+        $this->dungeon->coins = 0;
+        $this->dungeon->mana = 0;
+
+        $this->dungeon->collectArtifact();
+
+        $this->assertGreaterThan(0, $this->dungeon->coins);
+        $this->assertLessThan(100, $this->dungeon->stability);
+        $this->assertGreaterThan(0, $this->dungeon->mana);
+
+        $this->eventBus->assertDispatched(ArtifactCollected::class);
+        $this->eventBus->assertDispatched(ArtifactSpawned::class); // a new artifact is spawned afterwards
+    }
+
+    #[Test]
+    public function collect_artifact_does_nothing_when_player_is_not_on_artifact_location(): void
+    {
+        $this->dungeon->artifactLocation = new Point(99, 99);
+        $this->dungeon->coins = 0;
+
+        $this->dungeon->collectArtifact();
+
+        $this->assertSame(0, $this->dungeon->coins);
+        $this->eventBus->assertNotDispatched(ArtifactCollected::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // exit
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function exit_dungeon(): void
+    {
+        // Player starts on origin tile (0,0)
+
+        $this->dungeon->exit();
+
+        $this->assertTrue($this->dungeon->hasEnded);
+
+        $this->eventBus->assertDispatched(PlayerExited::class, function (PlayerExited $event) {
+            $this->assertSame($this->dungeon->user, $event->user);
+        });
+    }
+
+    #[Test]
+    public function exit_dungeon_does_nothing_when_not_on_origin_tile(): void
+    {
+        $this->dungeon->addTile(new Tile(new Point(1, 0)));
+        $this->dungeon->playerPosition = new Point(1, 0);
+
+        $this->dungeon->exit();
+
+        $this->assertFalse($this->dungeon->hasEnded);
+        $this->eventBus->assertNotDispatched(PlayerExited::class);
+    }
+
+    #[Test]
+    public function exit_dungeon_without_origin_requirement(): void
+    {
+        $this->dungeon->playerPosition = new Point(5, 5);
+
+        $this->dungeon->exit(requiresOrigin: false);
+
+        $this->assertTrue($this->dungeon->hasEnded);
+        $this->eventBus->assertDispatched(PlayerExited::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // resign
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function resign(): void
+    {
+        $this->dungeon->resign();
+
+        $this->assertTrue($this->dungeon->hasEnded);
+
+        $this->eventBus->assertDispatched(PlayerResigned::class, function (PlayerResigned $event) {
+            $this->assertSame($this->dungeon->user, $event->user);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // updateTile
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function update_tile(): void
+    {
+        $tile = $this->dungeon->currentTile;
+
+        $this->dungeon->updateTile($tile);
+
+        $this->eventBus->assertDispatched(TileUpdated::class, function (TileUpdated $event) use ($tile) {
+            $this->assertTrue($event->tile->point->equals($tile->point));
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseVictoryPoints
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function increase_victory_points(): void
+    {
+        $this->dungeon->increaseVictoryPoints(10);
+
+        $this->assertSame(10, $this->dungeon->victoryPoints);
+
+        $this->eventBus->assertDispatched(PlayerVictoryPointsIncreased::class, function (PlayerVictoryPointsIncreased $event) {
+            $this->assertSame(10, $event->amount);
+            $this->assertSame(10, $event->total);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseShards
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function increase_shards(): void
+    {
+        $this->dungeon->increaseShards(5);
+
+        $this->assertSame(5, $this->dungeon->shards);
+
+        $this->eventBus->assertDispatched(PlayerShardsIncreased::class, function (PlayerShardsIncreased $event) {
+            $this->assertSame(5, $event->amount);
+            $this->assertSame(5, $event->total);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // updateCard
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function update_card(): void
+    {
+        $card = new BeaconMinor();
+
+        $this->dungeon->updateCard($card);
+
+        $this->eventBus->assertDispatched(CardUpdated::class, function (CardUpdated $event) use ($card) {
+            $this->assertSame($card->id, $event->card->id);
+        });
+    }
+
+    #[Test]
+    public function mana_altar_grants_mana_when_cooldown_is_zero(): void
+    {
+        $point = new Point(1, 0);
+        $tile = new Tile($point, isManaAltar: true, altarCooldown: 0);
+        $this->dungeon->addTile($tile);
+        $manaBefore = $this->dungeon->mana;
+
+        $event = new PlayerMoved(from: new Point(0, 0), to: $point);
+        $this->container->get(PlayerMovementListener::class)->checkForManaAltar($event);
+
+        $this->assertGreaterThan($manaBefore, $this->dungeon->mana);
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class);
+    }
+
+    #[Test]
+    public function mana_altar_does_not_grant_mana_when_on_cooldown(): void
+    {
+        $this->dungeon->mana = 0;
+        $point = new Point(1, 0);
+        $tile = new Tile($point, isManaAltar: true, altarCooldown: 50);
+        $this->dungeon->addTile($tile);
+
+        $event = new PlayerMoved(from: new Point(0, 0), to: $point);
+        $this->container->get(PlayerMovementListener::class)->checkForManaAltar($event);
+
+        $this->assertSame(0, $this->dungeon->mana);
+        $this->eventBus->assertNotDispatched(PlayerManaIncreased::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Health altar
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function health_altar_grants_health_when_cooldown_is_zero(): void
+    {
+        $this->dungeon->health = 50;
+        $point = new Point(1, 0);
+        $tile = new Tile($point, isHealthAltar: true, altarCooldown: 0);
+        $this->dungeon->addTile($tile);
+
+        $event = new PlayerMoved(from: new Point(0, 0), to: $point);
+        $this->container->get(PlayerMovementListener::class)->checkForHealthAltar($event);
+
+        $this->assertGreaterThan(50, $this->dungeon->health);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class);
+    }
+
+    #[Test]
+    public function health_altar_does_not_grant_health_when_on_cooldown(): void
+    {
+        $this->dungeon->health = 50;
+        $point = new Point(1, 0);
+        $tile = new Tile($point, isHealthAltar: true, altarCooldown: 50);
+        $this->dungeon->addTile($tile);
+
+        $event = new PlayerMoved(from: new Point(0, 0), to: $point);
+        $this->container->get(PlayerMovementListener::class)->checkForHealthAltar($event);
+
+        $this->assertSame(50, $this->dungeon->health);
+        $this->eventBus->assertNotDispatched(PlayerHealthIncreased::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Stability altar
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function stability_altar_grants_stability_when_cooldown_is_zero(): void
+    {
+        $this->dungeon->stability = 50;
+        $point = new Point(1, 0);
+        $tile = new Tile($point, isStabilityAltar: true, altarCooldown: 0);
+        $this->dungeon->addTile($tile);
+
+        $event = new PlayerMoved(from: new Point(0, 0), to: $point);
+        $this->container->get(PlayerMovementListener::class)->checkForStabilityAltar($event);
+
+        $this->assertGreaterThan(50, $this->dungeon->stability);
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class);
+    }
+
+    #[Test]
+    public function stability_altar_does_not_grant_stability_when_on_cooldown(): void
+    {
+        $this->dungeon->stability = 50;
+        $point = new Point(1, 0);
+        $tile = new Tile($point, isStabilityAltar: true, altarCooldown: 50);
+        $this->dungeon->addTile($tile);
+
+        $event = new PlayerMoved(from: new Point(0, 0), to: $point);
+        $this->container->get(PlayerMovementListener::class)->checkForStabilityAltar($event);
+
+        $this->assertLessThanOrEqual(50, $this->dungeon->stability);
+        $this->eventBus->assertNotDispatched(PlayerStabilityIncreased::class);
+    }
+}

--- a/phpunit/Dungeon/DungeonTest.php
+++ b/phpunit/Dungeon/DungeonTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon;
+
+use App\Dungeon\Dungeon;
+use App\Dungeon\Repositories\DeckRepository;
+use App\Dungeon\Repositories\StatsRepository;
+use App\Dungeon\Support\DungeonInitializer;
+use App\Support\Authentication\User;
+use Tempest\Auth\Authentication\Authenticator;
+use Tests\PHPUnit\IntegrationTestCase;
+
+abstract class DungeonTest extends IntegrationTestCase
+{
+    protected Dungeon $dungeon;
+    protected User $user;
+
+    // No `#[Before]` here: PHPUnit already calls `setUp()` as its template method, and the attribute
+    // would register it a second time — running the whole fixture (and the migration) twice per test.
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Migrate DB
+        $this->database->migrate();
+
+        // Setup auth
+        $this->user = new User('Brent', 'example@example.com')->save();
+        $this->container->get(Authenticator::class)->authenticate($this->user);
+
+        // Setup stats
+        $statsRepository = $this->container->get(StatsRepository::class);
+        $statsRepository->forUser($this->user);
+
+        // Setup dungeon
+        $this->dungeon = Dungeon::new(
+            user: $this->user,
+            deckRepository: $this->container->get(DeckRepository::class),
+            statsRepository: $statsRepository,
+        );
+
+        $this->container->singleton(Dungeon::class, $this->dungeon);
+        $this->container->removeInitializer(DungeonInitializer::class);
+
+        // Setup event bus
+        $this->eventBus->preventEventHandling();
+    }
+}

--- a/phpunit/Dungeon/PlayerMovementListenerTest.php
+++ b/phpunit/Dungeon/PlayerMovementListenerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\PHPUnit\Dungeon;
+
+use App\Dungeon\Direction;
+use App\Dungeon\Dungeon;
+use App\Dungeon\Events\RelicCollected;
+use App\Dungeon\Point;
+use App\Dungeon\Repositories\DeckRepository;
+use App\Dungeon\Repositories\StatsRepository;
+use App\Dungeon\Support\DungeonInitializer;
+use App\Dungeon\Tile;
+use App\Support\Authentication\User;
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Auth\Authentication\Authenticator;
+use Tests\PHPUnit\IntegrationTestCase;
+
+final class PlayerMovementListenerTest extends IntegrationTestCase
+{
+    protected Dungeon $dungeon;
+    protected User $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->database->migrate();
+
+        $this->user = new User('Brent', 'example@example.com')->save();
+        $this->container->get(Authenticator::class)->authenticate($this->user);
+
+        $statsRepository = $this->container->get(StatsRepository::class);
+        $statsRepository->forUser($this->user);
+
+        $this->dungeon = Dungeon::new(
+            user: $this->user,
+            deckRepository: $this->container->get(DeckRepository::class),
+            statsRepository: $statsRepository,
+        );
+
+        $this->container->singleton(Dungeon::class, $this->dungeon);
+        $this->container->removeInitializer(DungeonInitializer::class);
+        // Record dispatches for assertions, but still execute listeners
+        $this->eventBus->recordEventDispatches(preventHandling: false);
+    }
+
+    // -------------------------------------------------------------------------
+    // Relic
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function moving_onto_relic_tile_collects_the_relic(): void
+    {
+        $this->dungeon->cheat = true;
+        $this->dungeon->addTile(new Tile(new Point(1, 0), isRelic: true));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        $this->eventBus->assertDispatched(RelicCollected::class, function (RelicCollected $event) {
+            $this->assertTrue($event->tile->point->equals(new Point(1, 0)));
+            $this->assertFalse($event->tile->isRelic);
+        });
+    }
+
+    #[Test]
+    public function moving_onto_non_relic_tile_does_not_dispatch_relic_collected(): void
+    {
+        $this->dungeon->cheat = true;
+        $this->dungeon->addTile(new Tile(new Point(1, 0)));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        $this->eventBus->assertNotDispatched(RelicCollected::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Mana altar
+    // -------------------------------------------------------------------------
+}

--- a/phpunit/IntegrationTestCase.php
+++ b/phpunit/IntegrationTestCase.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPUnit;
+
+use Tempest\Container\GenericContainer;
+use Tempest\Core\FrameworkKernel;
+use Tempest\Discovery\DiscoveryLocation;
+use Tempest\EventBus\EventBus;
+use Tempest\Framework\Testing\IntegrationTest;
+
+use function Tempest\env;
+
+/**
+ * Boots the framework kernel once per process instead of once per test.
+ *
+ * `IntegrationTest::setupKernel()` caches the kernel on the instance (`$this->kernel ??= …`), but
+ * `tearDown()` unsets it and PHPUnit builds a fresh test-case object for every test — so the guard
+ * never hits and the kernel is booted anew for each one. Caching it statically is what the tempest
+ * and Testo runners do; the price is that the container survives between tests, so its singletons
+ * and initializers are snapshotted here and rolled back afterwards.
+ */
+abstract class IntegrationTestCase extends IntegrationTest
+{
+    protected string $root = __DIR__ . '/../';
+
+    private static ?FrameworkKernel $bootedKernel = null;
+
+    private EventBus $originalEventBus;
+
+    private array $originalSingletons = [];
+
+    private array $originalDynamicInitializers = [];
+
+    /**
+     * `IntegrationTest::discoverTestLocations()` hardcodes `<root>/tests`, which is the Tempest
+     * runner's suite — this one would otherwise discover the other suite's tests and configs and
+     * never see its own. Each suite discovers its own tree, as `testo.php` does for Testo.
+     */
+    protected function discoverTestLocations(): array
+    {
+        return [new DiscoveryLocation('Tests\\PHPUnit\\', __DIR__)];
+    }
+
+    protected function setupKernel(): self
+    {
+        $this->internalStorage = $this->root . '/.tempest/test_internal_storage/' . env('TEST_TOKEN', 'default');
+
+        self::$bootedKernel ??= FrameworkKernel::boot(
+            root: $this->root,
+            discoveryLocations: [...$this->discoveryLocations, ...$this->discoverTestLocations()],
+            internalStorage: $this->internalStorage,
+        );
+
+        $this->kernel = self::$bootedKernel;
+
+        /** @var GenericContainer $container */
+        $container = $this->kernel->container;
+        $this->container = $container;
+
+        // `tearDown()` nulls the global instance, which a fresh boot would otherwise have restored.
+        GenericContainer::setInstance($container);
+
+        $this->originalSingletons = $container->getSingletons();
+        $this->originalDynamicInitializers = $container->getDynamicInitializers();
+        $this->originalEventBus = $container->get(EventBus::class);
+
+        return $this;
+    }
+
+    protected function tearDown(): void
+    {
+        $this->container->setSingletons($this->originalSingletons);
+        $this->container->setDynamicInitializers($this->originalDynamicInitializers);
+
+        // `EventBusTester::recordEventDispatches()` wraps whatever `EventBus` the container holds in
+        // a `FakeEventBus`. `setSingletons()` only swaps the definitions, so the resolved wrapper
+        // stays reachable and the layers would stack — a `preventHandling: true` one from an earlier
+        // test keeps swallowing events. `singleton()` drops the resolved instance too.
+        $this->container->singleton(EventBus::class, $this->originalEventBus);
+
+        parent::tearDown();
+    }
+}

--- a/phpunit/TestingDatabaseInitializer.php
+++ b/phpunit/TestingDatabaseInitializer.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPUnit;
+
+use Tempest\Container\Container;
+use Tempest\Container\DynamicInitializer;
+use Tempest\Container\Singleton;
+use Tempest\Database\Config\DatabaseConfig;
+use Tempest\Database\Connection\Connection;
+use Tempest\Database\Connection\PDOConnection;
+use Tempest\Database\Database;
+use Tempest\Database\GenericDatabase;
+use Tempest\Database\Transactions\GenericTransactionManager;
+use Tempest\EventBus\EventBus;
+use Tempest\Mapper\SerializerFactory;
+use Tempest\Reflection\ClassReflector;
+use UnitEnum;
+
+use function Tempest\Support\Str;
+
+final class TestingDatabaseInitializer implements DynamicInitializer
+{
+    /** @var Connection[] */
+    private static array $connections = [];
+
+    public function canInitialize(ClassReflector $class, string|UnitEnum|null $tag): bool
+    {
+        return $class->getType()->matches(Database::class);
+    }
+
+    #[Singleton]
+    public function initialize(ClassReflector $class, string|UnitEnum|null $tag, Container $container): Database
+    {
+        $tag = str($tag)->toString();
+
+        /** @var PDOConnection|null $connection */
+        $connection = self::$connections[$tag] ?? null;
+
+        if ($connection === null) {
+            $config = $container->get(DatabaseConfig::class, $tag);
+            $connection = new PDOConnection($config);
+            $connection->connect();
+
+            self::$connections[$tag] = $connection;
+        }
+
+        if ($connection->ping() === false) {
+            $connection->reconnect();
+        }
+
+        $container->singleton(Connection::class, $connection, $tag);
+
+        return new GenericDatabase(
+            $connection,
+            new GenericTransactionManager($connection),
+            $container->get(SerializerFactory::class),
+            $container->get(EventBus::class),
+        );
+    }
+}

--- a/phpunit/database.testing.config.php
+++ b/phpunit/database.testing.config.php
@@ -1,0 +1,13 @@
+<?php
+
+use Tempest\Database\Config\MysqlConfig;
+
+use function Tempest\env;
+
+return new MysqlConfig(
+    host: env('TEST_DATABASE_HOST', default: 'localhost'),
+    port: env('TEST_DATABASE_PORT', default: '3306'),
+    username: env('TEST_DATABASE_USERNAME', default: 'root'),
+    password: env('TEST_DATABASE_PASSWORD', default: ''),
+    database: env('TEST_DATABASE_DATABASE', default: 'stitcher-testing'),
+);

--- a/phpunit/redis.testing.config.php
+++ b/phpunit/redis.testing.config.php
@@ -1,0 +1,10 @@
+<?php
+
+use Tempest\KeyValue\Redis\Config\RedisConfig;
+
+use function Tempest\env;
+
+return new RedisConfig(
+    host: env('TEST_REDIS_HOST', default: '127.0.0.1'),
+    port: (int) env('TEST_REDIS_PORT', default: 6379),
+);

--- a/skills.json
+++ b/skills.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://raw.githubusercontent.com/roxblnfk/skills/master/resources/skills.schema.json",
+    "aliases": [
+        ".claude/skills"
+    ]
+}

--- a/testo.php
+++ b/testo.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Testo\Application\Config\ApplicationConfig;
+use Testo\Application\Config\FinderConfig;
+use Testo\Application\Config\SuiteConfig;
+
+/**
+ * The Tempest kernel reads its environment through `getenv()`, and `Dotenv` is loaded immutably —
+ * so these win over `.env`. This is the Testo counterpart of `phpunit.xml`'s `<php><env>` block.
+ */
+foreach (['ENVIRONMENT' => 'testing', 'BASE_URI' => '', 'CACHE' => 'null'] as $key => $value) {
+    putenv("{$key}={$value}");
+}
+
+return new ApplicationConfig(
+    src: new FinderConfig(include: ['app']),
+    suites: [
+        new SuiteConfig(
+            name: 'Integration',
+            location: ['testo/Analytics', 'testo/Dungeon'],
+        ),
+    ],
+);

--- a/testo/Analytics/TestsAnalytics.php
+++ b/testo/Analytics/TestsAnalytics.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Analytics;
+
+use App\Analytics\PageVisited;
+use DateTimeImmutable;
+use Testo\Lifecycle\BeforeTest;
+
+use function Tempest\EventBus\event;
+
+trait TestsAnalytics
+{
+    /**
+     * Projections accumulate, so every analytics test needs an empty set of tables.
+     *
+     * Runs after `IntegrationTestCase::setUpTempest()`, which holds a higher priority.
+     */
+    #[BeforeTest]
+    public function resetAnalyticsTables(): void
+    {
+        $this->database->reset();
+    }
+
+    private function triggerVisit(
+        string $date = '2026-01-01 10:00:10',
+        string $uri = 'https://example.com',
+    ): void {
+        event(new PageVisited(
+            url: $uri,
+            visitedAt: new DateTimeImmutable($date),
+            ip: '127.0.0.1',
+            userAgent: 'Test',
+            raw: 'Test',
+        ));
+    }
+}

--- a/testo/Analytics/VisitsPerDay/VisitsPerDayProjectorTest.php
+++ b/testo/Analytics/VisitsPerDay/VisitsPerDayProjectorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Analytics\VisitsPerDay;
+
+use App\Analytics\VisitsPerDay\VisitsPerDayProjector;
+use Testo\Test;
+use Tests\Testo\Analytics\TestsAnalytics;
+use Tests\Testo\Support\IntegrationTestCase;
+
+#[Test]
+class VisitsPerDayProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-01');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_day',
+            date: '2026-01-01 00:00:00',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-01');
+        $this->triggerVisit('2026-01-02');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_day',
+            date: '2026-01-01 00:00:00',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_day',
+            date: '2026-01-02 00:00:00',
+            count: 1,
+        );
+    }
+
+    public function replay_test(): void
+    {
+        $this->triggerVisit();
+        $this->triggerVisit();
+        $this->triggerVisit();
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerDayProjector::class))->succeeds();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_day',
+            date: '2026-01-01 00:00:00',
+            count: 3,
+        );
+    }
+}

--- a/testo/Analytics/VisitsPerHour/VisitsPerHourProjectorTest.php
+++ b/testo/Analytics/VisitsPerHour/VisitsPerHourProjectorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Analytics\VisitsPerHour;
+
+use App\Analytics\VisitsPerHour\VisitsPerHourProjector;
+use Testo\Test;
+use Tests\Testo\Analytics\TestsAnalytics;
+use Tests\Testo\Support\IntegrationTestCase;
+
+#[Test]
+class VisitsPerHourProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-01 01:10:00');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_hour',
+            hour: '2026-01-01 01:00:00',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-01 01:10:00');
+        $this->triggerVisit('2026-01-01 02:10:00');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_hour',
+            hour: '2026-01-01 01:00:00',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_hour',
+            hour: '2026-01-01 02:00:00',
+            count: 1,
+        );
+    }
+
+    public function replay_test(): void
+    {
+        $this->triggerVisit('2026-01-01 01:00:00');
+        $this->triggerVisit('2026-01-01 01:00:00');
+        $this->triggerVisit('2026-01-01 01:00:00');
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerHourProjector::class))->succeeds();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_hour',
+            hour: '2026-01-01 01:00:00',
+            count: 3,
+        );
+    }
+}

--- a/testo/Analytics/VisitsPerMinute/VisitsPerMinuteProjectorTest.php
+++ b/testo/Analytics/VisitsPerMinute/VisitsPerMinuteProjectorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Analytics\VisitsPerMinute;
+
+use App\Analytics\VisitsPerMinute\VisitsPerMinuteProjector;
+use Testo\Test;
+use Tests\Testo\Analytics\TestsAnalytics;
+use Tests\Testo\Support\IntegrationTestCase;
+
+#[Test]
+class VisitsPerMinuteProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-01 10:10:40');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_minute',
+            time: '2026-01-01 10:10:00',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-01 10:10:30');
+        $this->triggerVisit('2026-01-01 10:11:30');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_minute',
+            time: '2026-01-01 10:10:00',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_minute',
+            time: '2026-01-01 10:11:00',
+            count: 1,
+        );
+    }
+
+    public function replay_test(): void
+    {
+        $this->triggerVisit('2026-01-01 10:10:40');
+        $this->triggerVisit('2026-01-01 10:10:41');
+        $this->triggerVisit('2026-01-01 10:10:42');
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerMinuteProjector::class))->succeeds();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_minute',
+            time: '2026-01-01 10:10:00',
+            count: 3,
+        );
+    }
+}

--- a/testo/Analytics/VisitsPerMonth/VisitsPerMonthProjectorTest.php
+++ b/testo/Analytics/VisitsPerMonth/VisitsPerMonthProjectorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Analytics\VisitsPerMonth;
+
+use App\Analytics\VisitsPerMonth\VisitsPerMonthProjector;
+use Testo\Test;
+use Tests\Testo\Analytics\TestsAnalytics;
+use Tests\Testo\Support\IntegrationTestCase;
+
+#[Test]
+class VisitsPerMonthProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-05');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_month',
+            date: '2026-01-01',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-10');
+        $this->triggerVisit('2026-02-10');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_month',
+            date: '2026-01-01',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_month',
+            date: '2026-02-01',
+            count: 1,
+        );
+    }
+
+    public function replay_test(): void
+    {
+        $this->triggerVisit('2026-01-10');
+        $this->triggerVisit('2026-01-10');
+        $this->triggerVisit('2026-01-10');
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerMonthProjector::class))->succeeds();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_month',
+            date: '2026-01-01',
+            count: 3,
+        );
+    }
+}

--- a/testo/Analytics/VisitsPerPostPerDay/VisitsPerPostPerDayProjectorTest.php
+++ b/testo/Analytics/VisitsPerPostPerDay/VisitsPerPostPerDayProjectorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Analytics\VisitsPerPostPerDay;
+
+use App\Analytics\VisitsPerPostPerDay\VisitsPerPostPerDayProjector;
+use Testo\Test;
+use Tests\Testo\Analytics\TestsAnalytics;
+use Tests\Testo\Support\IntegrationTestCase;
+
+#[Test]
+class VisitsPerPostPerDayProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-05 10:00:00', '/a');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-05 00:00:00',
+            uri: '/a',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-05 10:00:00', '/a');
+        $this->triggerVisit('2026-01-05 10:00:00', '/b');
+        $this->triggerVisit('2026-01-06 10:00:00', '/a');
+        $this->triggerVisit('2026-01-06 10:00:00', '/b');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-05 00:00:00',
+            uri: '/a',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-05 00:00:00',
+            uri: '/b',
+            count: 1,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-06 00:00:00',
+            uri: '/a',
+            count: 1,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-06 00:00:00',
+            uri: '/b',
+            count: 1,
+        );
+    }
+
+    public function replay_test(): void
+    {
+        $this->triggerVisit('2026-01-10 10:00:00', '/a');
+        $this->triggerVisit('2026-01-10 10:00:00', '/a');
+        $this->triggerVisit('2026-01-10 10:00:00', '/b');
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerPostPerDayProjector::class))->succeeds();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-10 00:00:00',
+            uri: '/a',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_day',
+            date: '2026-01-10 00:00:00',
+            uri: '/b',
+            count: 1,
+        );
+    }
+}

--- a/testo/Analytics/VisitsPerPostPerWeek/VisitsPerPostPerWeekProjectorTest.php
+++ b/testo/Analytics/VisitsPerPostPerWeek/VisitsPerPostPerWeekProjectorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Analytics\VisitsPerPostPerWeek;
+
+use App\Analytics\VisitsPerPostPerWeek\VisitsPerPostPerWeekProjector;
+use Testo\Test;
+use Tests\Testo\Analytics\TestsAnalytics;
+use Tests\Testo\Support\IntegrationTestCase;
+
+#[Test]
+class VisitsPerPostPerWeekProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-06 ', '/a');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-05',
+            uri: '/a',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-06 ', '/a');
+        $this->triggerVisit('2026-01-06 ', '/b');
+        $this->triggerVisit('2026-01-13 ', '/a');
+        $this->triggerVisit('2026-01-13 ', '/b');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-05',
+            uri: '/a',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-05',
+            uri: '/b',
+            count: 1,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-12',
+            uri: '/a',
+            count: 1,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-12',
+            uri: '/b',
+            count: 1,
+        );
+    }
+
+    public function replay_test(): void
+    {
+        $this->triggerVisit('2026-01-06 ', '/a');
+        $this->triggerVisit('2026-01-06 ', '/a');
+        $this->triggerVisit('2026-01-06 ', '/b');
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerPostPerWeekProjector::class))->succeeds();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-05',
+            uri: '/a',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_post_per_week',
+            date: '2026-01-05',
+            uri: '/b',
+            count: 1,
+        );
+    }
+}

--- a/testo/Analytics/VisitsPerYear/VisitsPerYearProjectorTest.php
+++ b/testo/Analytics/VisitsPerYear/VisitsPerYearProjectorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Analytics\VisitsPerYear;
+
+use App\Analytics\VisitsPerYear\VisitsPerYearProjector;
+use Testo\Test;
+use Tests\Testo\Analytics\TestsAnalytics;
+use Tests\Testo\Support\IntegrationTestCase;
+
+#[Test]
+class VisitsPerYearProjectorTest extends IntegrationTestCase
+{
+    use TestsAnalytics;
+
+    public function events_are_persisted(): void
+    {
+        $this->triggerVisit('2026-01-05');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_year',
+            date: '2026-01-01',
+            count: 1,
+        );
+
+        $this->triggerVisit('2026-01-10');
+        $this->triggerVisit('2025-02-10');
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_year',
+            date: '2026-01-01',
+            count: 2,
+        );
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_year',
+            date: '2025-01-01',
+            count: 1,
+        );
+    }
+
+    public function replay_test(): void
+    {
+        $this->triggerVisit('2026-01-10');
+        $this->triggerVisit('2026-01-10');
+        $this->triggerVisit('2026-01-10');
+
+        $this->console->call(sprintf('replay "%s" --force', VisitsPerYearProjector::class))->succeeds();
+
+        $this->database->assertTableHasRow(
+            table: 'visits_per_year',
+            date: '2026-01-01',
+            count: 3,
+        );
+    }
+}

--- a/testo/Dungeon/Cards/BeaconMajorTest.php
+++ b/testo/Dungeon/Cards/BeaconMajorTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\BeaconMajor;
+use App\Dungeon\Events\CardPlayed;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\DwellerUpdated;
+use App\Dungeon\Events\PassiveCardUnset;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class BeaconMajorTest extends DungeonTest
+{
+    // -------------------------------------------------------------------------
+    // play()
+    // -------------------------------------------------------------------------
+
+    public function play_shows_all_hidden_dwellers(): void
+    {
+        $card = new BeaconMajor();
+        $point = new Point(3, 0);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $card->play($this->dungeon);
+
+        Assert::true($dweller->isVisible);
+        $this->eventBus->assertDispatched(DwellerUpdated::class);
+    }
+
+    public function play_does_nothing_when_no_dwellers_exist(): void
+    {
+        $card = new BeaconMajor();
+        $this->dungeon->dwellers = []; // clear initial dungeon dwellers
+
+        $card->play($this->dungeon);
+
+        $this->eventBus->assertNotDispatched(DwellerUpdated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // handle() — PlayerMoved
+    // -------------------------------------------------------------------------
+
+    public function handle_decrements_count_on_player_moved(): void
+    {
+        $card = new BeaconMajor();
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        Assert::same($card->count, 24);
+    }
+
+    public function handle_updates_card_on_player_moved(): void
+    {
+        $card = new BeaconMajor();
+        $this->dungeon->setPassiveCard($card);
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function handle_shows_dwellers_while_count_is_above_zero(): void
+    {
+        $card = new BeaconMajor();
+        $point = new Point(3, 0);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        Assert::true($dweller->isVisible);
+        Assert::same($card->count, 24);
+    }
+
+    public function handle_hides_dweller_outside_visibility_radius_when_count_reaches_zero(): void
+    {
+        $card = new BeaconMajor();
+        $card->count = 1;
+        $this->dungeon->setPassiveCard($card);
+
+        // Dweller far outside visibility radius (default radius is 5)
+        $farPoint = new Point(20, 0);
+        $this->dungeon->spawnDweller($farPoint);
+        $dweller = $this->dungeon->getDweller($farPoint);
+        $dweller->isVisible = true;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        Assert::same($card->count, 0);
+        Assert::false($dweller->isVisible);
+        Assert::null($this->dungeon->passiveCard);
+    }
+
+    public function handle_does_not_hide_dweller_inside_visibility_radius_when_count_reaches_zero(): void
+    {
+        $card = new BeaconMajor();
+        $card->count = 1;
+        $this->dungeon->setPassiveCard($card);
+
+        // Dweller within visibility radius (default radius is 5)
+        $nearPoint = new Point(2, 0);
+        $this->dungeon->spawnDweller($nearPoint);
+        $dweller = $this->dungeon->getDweller($nearPoint);
+        $dweller->isVisible = true;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        Assert::same($card->count, 0);
+        Assert::true($dweller->isVisible);
+        Assert::null($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PassiveCardUnset::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // handle() — CardPlayed
+    // -------------------------------------------------------------------------
+
+    public function handle_does_not_decrement_count_on_card_played(): void
+    {
+        $card = new BeaconMajor();
+        $this->dungeon->setPassiveCard($card);
+
+        $card->handle($this->dungeon, new CardPlayed($card));
+
+        Assert::same($card->count, 25);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function handle_shows_dwellers_on_card_played(): void
+    {
+        $card = new BeaconMajor();
+        $point = new Point(3, 0);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $card->handle($this->dungeon, new CardPlayed($card));
+
+        Assert::true($dweller->isVisible);
+    }
+
+    // -------------------------------------------------------------------------
+    // handle() — other events
+    // -------------------------------------------------------------------------
+
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new BeaconMajor();
+
+        $card->handle(
+            $this->dungeon,
+            new TileGenerated(
+                new Tile(new Point(1, 0)),
+            ),
+        );
+
+        Assert::same($card->count, 25);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/testo/Dungeon/Cards/BeaconMinorTest.php
+++ b/testo/Dungeon/Cards/BeaconMinorTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\BeaconMinor;
+use App\Dungeon\Events\CardPlayed;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\DwellerUpdated;
+use App\Dungeon\Events\PassiveCardUnset;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class BeaconMinorTest extends DungeonTest
+{
+    // -------------------------------------------------------------------------
+    // play()
+    // -------------------------------------------------------------------------
+
+    public function play_shows_all_hidden_dwellers(): void
+    {
+        $card = new BeaconMinor();
+        $point = new Point(3, 0);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $card->play($this->dungeon);
+
+        Assert::true($dweller->isVisible);
+        $this->eventBus->assertDispatched(DwellerUpdated::class);
+    }
+
+    public function play_does_nothing_when_no_dwellers_exist(): void
+    {
+        $card = new BeaconMinor();
+        $this->dungeon->dwellers = [];
+
+        $card->play($this->dungeon);
+
+        $this->eventBus->assertNotDispatched(DwellerUpdated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // handle() — PlayerMoved
+    // -------------------------------------------------------------------------
+
+    public function handle_decrements_count_on_player_moved(): void
+    {
+        $card = new BeaconMinor();
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        Assert::same($card->count, 9);
+    }
+
+    public function handle_updates_card_on_player_moved(): void
+    {
+        $card = new BeaconMinor();
+        $this->dungeon->setPassiveCard($card);
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function handle_shows_dwellers_while_count_is_above_zero(): void
+    {
+        $card = new BeaconMinor();
+        $point = new Point(3, 0);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        Assert::true($dweller->isVisible);
+        Assert::same($card->count, 9);
+    }
+
+    public function handle_hides_dweller_outside_visibility_radius_when_count_reaches_zero(): void
+    {
+        $card = new BeaconMinor();
+        $card->count = 1;
+        $this->dungeon->setPassiveCard($card);
+
+        $farPoint = new Point(20, 0);
+        $this->dungeon->spawnDweller($farPoint);
+        $dweller = $this->dungeon->getDweller($farPoint);
+        $dweller->isVisible = true;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        Assert::same($card->count, 0);
+        Assert::false($dweller->isVisible);
+        Assert::null($this->dungeon->passiveCard);
+    }
+
+    public function handle_does_not_hide_dweller_inside_visibility_radius_when_count_reaches_zero(): void
+    {
+        $card = new BeaconMinor();
+        $card->count = 1;
+        $this->dungeon->setPassiveCard($card);
+
+        $nearPoint = new Point(2, 0);
+        $this->dungeon->spawnDweller($nearPoint);
+        $dweller = $this->dungeon->getDweller($nearPoint);
+        $dweller->isVisible = true;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        Assert::same($card->count, 0);
+        Assert::true($dweller->isVisible);
+        Assert::null($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PassiveCardUnset::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // handle() — CardPlayed
+    // -------------------------------------------------------------------------
+
+    public function handle_does_not_decrement_count_on_card_played(): void
+    {
+        $card = new BeaconMinor();
+        $this->dungeon->setPassiveCard($card);
+
+        $card->handle($this->dungeon, new CardPlayed($card));
+
+        Assert::same($card->count, 10);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // handle() — other events
+    // -------------------------------------------------------------------------
+
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new BeaconMinor();
+
+        $card->handle(
+            $this->dungeon,
+            new TileGenerated(
+                new Tile(new Point(1, 0)),
+            ),
+        );
+
+        Assert::same($card->count, 10);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/testo/Dungeon/Cards/BreakthroughMajorTest.php
+++ b/testo/Dungeon/Cards/BreakthroughMajorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\BreakthroughMajor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerStabilityDecreased;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class BreakthroughMajorTest extends DungeonTest
+{
+    public function interact_with_tile_removes_walls_and_decreases_stability(): void
+    {
+        $card = new BreakthroughMajor();
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+        $this->dungeon->stability = 80;
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::same($this->dungeon->stability, 70);
+        Assert::same($card->count, 2);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            Assert::same($event->amount, 10);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function interact_with_tile_unsets_active_card_when_count_reaches_zero(): void
+    {
+        $card = new BreakthroughMajor();
+        $card->count = 1;
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::same($card->count, 0);
+        Assert::null($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    public function interact_with_tile_does_not_unset_active_card_while_count_is_above_zero(): void
+    {
+        $card = new BreakthroughMajor(); // count = 3
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::notNull($this->dungeon->activeCard);
+        $this->eventBus->assertNotDispatched(ActiveCardUnset::class);
+    }
+
+    public function can_interact_with_tile_returns_false_for_collapsed_tile(): void
+    {
+        $card = new BreakthroughMajor();
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+
+        Assert::false($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    public function can_interact_with_tile_returns_true_for_normal_tile(): void
+    {
+        $card = new BreakthroughMajor();
+        $tile = new Tile(new Point(1, 0));
+
+        Assert::true($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/testo/Dungeon/Cards/BreakthroughMinorTest.php
+++ b/testo/Dungeon/Cards/BreakthroughMinorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\BreakthroughMinor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerStabilityDecreased;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class BreakthroughMinorTest extends DungeonTest
+{
+    public function interact_with_tile_removes_walls_decreases_stability_and_unsets_active_card(): void
+    {
+        $card = new BreakthroughMinor();
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+        $this->dungeon->stability = 80;
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::same($this->dungeon->stability, 60);
+        Assert::null($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            Assert::same($event->amount, 20);
+        });
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function can_interact_with_tile_returns_false_for_collapsed_tile(): void
+    {
+        $card = new BreakthroughMinor();
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+
+        Assert::false($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    public function can_interact_with_tile_returns_true_for_normal_tile(): void
+    {
+        $card = new BreakthroughMinor();
+        $tile = new Tile(new Point(1, 0));
+
+        Assert::true($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/testo/Dungeon/Cards/ChestplateMajorPermanentTest.php
+++ b/testo/Dungeon/Cards/ChestplateMajorPermanentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\ChestplateMajorPermanent;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerHealthDecreased;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Point;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class ChestplateMajorPermanentTest extends DungeonTest
+{
+    public function handle_restores_up_to_10_health_on_damage(): void
+    {
+        $card = new ChestplateMajorPermanent();
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(15, 70, null));
+
+        Assert::same($this->dungeon->health, 80);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 10);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function handle_restores_only_the_actual_damage_when_damage_is_less_than_10(): void
+    {
+        $card = new ChestplateMajorPermanent();
+        $this->dungeon->health = 95;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(5, 95, null));
+
+        Assert::same($this->dungeon->health, 100);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 5);
+        });
+    }
+
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new ChestplateMajorPermanent();
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerMoved(
+            from: new Point(0, 0),
+            to: new Point(1, 0),
+        ));
+
+        Assert::same($this->dungeon->health, 70);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/testo/Dungeon/Cards/ChestplateMinorPermanentTest.php
+++ b/testo/Dungeon/Cards/ChestplateMinorPermanentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\ChestplateMinorPermanent;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerHealthDecreased;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Point;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class ChestplateMinorPermanentTest extends DungeonTest
+{
+    public function handle_restores_up_to_5_health_on_damage(): void
+    {
+        $card = new ChestplateMinorPermanent();
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(10, 70, null));
+
+        Assert::same($this->dungeon->health, 75);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 5);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function handle_restores_only_the_actual_damage_when_damage_is_less_than_5(): void
+    {
+        $card = new ChestplateMinorPermanent();
+        $this->dungeon->health = 98;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(2, 98, null));
+
+        Assert::same($this->dungeon->health, 100);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 2);
+        });
+    }
+
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new ChestplateMinorPermanent();
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerMoved(
+            from: new Point(0, 0),
+            to: new Point(1, 0),
+        ));
+
+        Assert::same($this->dungeon->health, 70);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/testo/Dungeon/Cards/ClarityTest.php
+++ b/testo/Dungeon/Cards/ClarityTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\Clarity;
+use App\Dungeon\Events\PlayerStabilityIncreased;
+use App\Dungeon\Events\VisibilityChanged;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class ClarityTest extends DungeonTest
+{
+    public function play_increases_visibility_radius_by_one(): void
+    {
+        $radiusBefore = $this->dungeon->visibilityRadius;
+        $card = new Clarity();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->visibilityRadius, $radiusBefore + 1);
+        $this->eventBus->assertDispatched(VisibilityChanged::class, function (VisibilityChanged $event) use ($radiusBefore) {
+            Assert::same($event->visibilityRadius, $radiusBefore + 1);
+        });
+    }
+
+    public function play_increases_stability_by_20(): void
+    {
+        $this->dungeon->stability = 50;
+        $card = new Clarity();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->stability, 70);
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            Assert::same($event->amount, 20);
+        });
+    }
+}

--- a/testo/Dungeon/Cards/EmergencyExitMajorTest.php
+++ b/testo/Dungeon/Cards/EmergencyExitMajorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\EmergencyExitMajor;
+use App\Dungeon\Events\PlayerExited;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class EmergencyExitMajorTest extends DungeonTest
+{
+    public function play_exits_with_65_percent_of_coins(): void
+    {
+        $this->dungeon->coins = 100;
+        $card = new EmergencyExitMajor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->coins, 65);
+        Assert::true($this->dungeon->hasEnded);
+        $this->eventBus->assertDispatched(PlayerExited::class, function (PlayerExited $event) {
+            Assert::same($event->coins, 65);
+        });
+    }
+
+    public function play_exits_without_requiring_origin_tile(): void
+    {
+        $this->dungeon->coins = 0;
+        $card = new EmergencyExitMajor();
+
+        $card->play($this->dungeon);
+
+        Assert::true($this->dungeon->hasEnded);
+    }
+}

--- a/testo/Dungeon/Cards/EmergencyExitMinorTest.php
+++ b/testo/Dungeon/Cards/EmergencyExitMinorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\EmergencyExitMinor;
+use App\Dungeon\Events\PlayerExited;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class EmergencyExitMinorTest extends DungeonTest
+{
+    public function play_exits_with_30_percent_of_coins(): void
+    {
+        $this->dungeon->coins = 100;
+        $card = new EmergencyExitMinor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->coins, 30);
+        Assert::true($this->dungeon->hasEnded);
+        $this->eventBus->assertDispatched(PlayerExited::class, function (PlayerExited $event) {
+            Assert::same($event->coins, 30);
+        });
+    }
+
+    public function play_exits_without_requiring_origin_tile(): void
+    {
+        $this->dungeon->coins = 0;
+        $card = new EmergencyExitMinor();
+
+        $card->play($this->dungeon);
+
+        Assert::true($this->dungeon->hasEnded);
+    }
+}

--- a/testo/Dungeon/Cards/GreedTest.php
+++ b/testo/Dungeon/Cards/GreedTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\Greed;
+use App\Dungeon\Events\PlayerStabilityDecreased;
+use App\Dungeon\Events\TileCoinsCollected;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class GreedTest extends DungeonTest
+{
+    public function play_collects_all_coins_from_tiles(): void
+    {
+        $tile = new Tile(new Point(1, 0), coins: 10);
+        $this->dungeon->addTile($tile);
+        $card = new Greed();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->coins, 10);
+        $this->eventBus->assertDispatched(TileCoinsCollected::class);
+    }
+
+    public function play_decreases_stability_by_20(): void
+    {
+        $this->dungeon->stability = 80;
+        $card = new Greed();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->stability, 60);
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            Assert::same($event->amount, 20);
+        });
+    }
+}

--- a/testo/Dungeon/Cards/HealMajorTest.php
+++ b/testo/Dungeon/Cards/HealMajorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\HealMajor;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class HealMajorTest extends DungeonTest
+{
+    public function play_increases_health_by_50(): void
+    {
+        $this->dungeon->health = 40;
+        $card = new HealMajor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->health, 90);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 50);
+        });
+    }
+
+    public function play_is_capped_at_max_health(): void
+    {
+        $this->dungeon->health = 80; // max is 100
+        $card = new HealMajor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->health, 100);
+    }
+}

--- a/testo/Dungeon/Cards/HealMinorTest.php
+++ b/testo/Dungeon/Cards/HealMinorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class HealMinorTest extends DungeonTest
+{
+    public function play_increases_health_by_25(): void
+    {
+        $this->dungeon->health = 50;
+        $card = new HealMinor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->health, 75);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 25);
+        });
+    }
+
+    public function play_is_capped_at_max_health(): void
+    {
+        $this->dungeon->health = 90;
+        $card = new HealMinor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->health, 100);
+    }
+}

--- a/testo/Dungeon/Cards/HealthIncreaseMajorTest.php
+++ b/testo/Dungeon/Cards/HealthIncreaseMajorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\HealthIncreaseMajor;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerMaxHealthIncreased;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class HealthIncreaseMajorTest extends DungeonTest
+{
+    public function play_increases_max_health_by_50(): void
+    {
+        $maxHealthBefore = $this->dungeon->maxHealth;
+        $card = new HealthIncreaseMajor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->maxHealth, $maxHealthBefore + 50);
+        $this->eventBus->assertDispatched(PlayerMaxHealthIncreased::class, function (PlayerMaxHealthIncreased $event) {
+            Assert::same($event->amount, 50);
+        });
+    }
+
+    public function play_increases_current_health_by_40(): void
+    {
+        $this->dungeon->health = 10;
+        $this->dungeon->maxHealth = 200; // room to grow
+        $card = new HealthIncreaseMajor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->health, 50);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 40);
+        });
+    }
+}

--- a/testo/Dungeon/Cards/HealthIncreaseMinorTest.php
+++ b/testo/Dungeon/Cards/HealthIncreaseMinorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\HealthIncreaseMinor;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerMaxHealthIncreased;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class HealthIncreaseMinorTest extends DungeonTest
+{
+    public function play_increases_max_health_by_25(): void
+    {
+        $maxHealthBefore = $this->dungeon->maxHealth;
+        $card = new HealthIncreaseMinor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->maxHealth, $maxHealthBefore + 25);
+        $this->eventBus->assertDispatched(PlayerMaxHealthIncreased::class, function (PlayerMaxHealthIncreased $event) {
+            Assert::same($event->amount, 25);
+        });
+    }
+
+    public function play_increases_current_health_by_15(): void
+    {
+        $this->dungeon->health = 10;
+        $this->dungeon->maxHealth = 200; // room to grow
+        $card = new HealthIncreaseMinor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->health, 25);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 15);
+        });
+    }
+}

--- a/testo/Dungeon/Cards/KillDwellerMajorTest.php
+++ b/testo/Dungeon/Cards/KillDwellerMajorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\KillDwellerMajor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\DwellerDespawned;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class KillDwellerMajorTest extends DungeonTest
+{
+    public function interact_with_tile_despawns_dweller_at_tile(): void
+    {
+        $card = new KillDwellerMajor();
+        $point = new Point(2, 0);
+        $tile = new Tile($point);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->spawnDweller($point);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::null($this->dungeon->getDweller($point));
+        $this->eventBus->assertDispatched(DwellerDespawned::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function interact_with_tile_unsets_active_card_after_three_uses(): void
+    {
+        $card = new KillDwellerMajor();
+        $this->dungeon->setActiveCard($card);
+
+        for ($i = 0; $i < 3; $i++) {
+            $point = new Point($i + 1, 0);
+            $tile = new Tile($point);
+            $this->dungeon->addTile($tile);
+            $this->dungeon->spawnDweller($point);
+            $card->interactWithTile($this->dungeon, $tile);
+        }
+
+        Assert::null($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    public function interact_with_tile_does_not_unset_card_before_three_uses(): void
+    {
+        $card = new KillDwellerMajor();
+        $this->dungeon->setActiveCard($card);
+        $point = new Point(2, 0);
+        $tile = new Tile($point);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->spawnDweller($point);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::notNull($this->dungeon->activeCard);
+        $this->eventBus->assertNotDispatched(ActiveCardUnset::class);
+    }
+
+    public function can_interact_with_tile_returns_true_when_dweller_is_present(): void
+    {
+        $card = new KillDwellerMajor();
+        $point = new Point(2, 0);
+        $tile = new Tile($point);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->spawnDweller($point);
+
+        Assert::true($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    public function can_interact_with_tile_returns_false_when_no_dweller_present(): void
+    {
+        $card = new KillDwellerMajor();
+        $tile = new Tile(new Point(2, 0));
+
+        Assert::false($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/testo/Dungeon/Cards/KillDwellerMinorTest.php
+++ b/testo/Dungeon/Cards/KillDwellerMinorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\KillDwellerMinor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\DwellerDespawned;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class KillDwellerMinorTest extends DungeonTest
+{
+    public function interact_with_tile_despawns_dweller_and_unsets_active_card(): void
+    {
+        $card = new KillDwellerMinor();
+        $this->dungeon->setActiveCard($card);
+        $point = new Point(2, 0);
+        $tile = new Tile($point);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->spawnDweller($point);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::null($this->dungeon->getDweller($point));
+        Assert::null($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(DwellerDespawned::class);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function can_interact_with_tile_returns_true_when_dweller_is_present(): void
+    {
+        $card = new KillDwellerMinor();
+        $point = new Point(2, 0);
+        $tile = new Tile($point);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->spawnDweller($point);
+
+        Assert::true($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    public function can_interact_with_tile_returns_false_when_no_dweller_present(): void
+    {
+        $card = new KillDwellerMinor();
+        $tile = new Tile(new Point(2, 0));
+
+        Assert::false($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/testo/Dungeon/Cards/LocateHealthAltarTest.php
+++ b/testo/Dungeon/Cards/LocateHealthAltarTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\LocateHealthAltar;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class LocateHealthAltarTest extends DungeonTest
+{
+    public function play_generates_tile_at_undiscovered_health_altar(): void
+    {
+        $altarPoint = new Point(5, 5);
+        $this->dungeon->healthAltars[$altarPoint->x][$altarPoint->y] = $altarPoint;
+        $card = new LocateHealthAltar();
+
+        $card->play($this->dungeon);
+
+        Assert::notNull($this->dungeon->tryTile($altarPoint));
+        $this->eventBus->assertDispatched(TileGenerated::class, function (TileGenerated $event) use ($altarPoint) {
+            Assert::true($event->tile->point->equals($altarPoint));
+        });
+    }
+
+    public function play_skips_altar_that_already_has_a_tile(): void
+    {
+        $altarPoint = new Point(5, 5);
+        $this->dungeon->healthAltars[$altarPoint->x][$altarPoint->y] = $altarPoint;
+        $this->dungeon->generateTile(null, $altarPoint); // already discovered
+        $card = new LocateHealthAltar();
+
+        $card->play($this->dungeon);
+
+        // TileGenerated was dispatched for the pre-generated tile, not by the card
+        $this->eventBus->assertDispatched(TileGenerated::class);
+    }
+
+    public function play_does_nothing_when_no_health_altars_exist(): void
+    {
+        $this->dungeon->healthAltars = [];
+        $card = new LocateHealthAltar();
+
+        $card->play($this->dungeon);
+
+        $this->eventBus->assertNotDispatched(TileGenerated::class);
+    }
+}

--- a/testo/Dungeon/Cards/LocateManaAltarTest.php
+++ b/testo/Dungeon/Cards/LocateManaAltarTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\LocateManaAltar;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class LocateManaAltarTest extends DungeonTest
+{
+    public function play_generates_tile_at_undiscovered_mana_altar(): void
+    {
+        $altarPoint = new Point(5, 5);
+        $this->dungeon->manaAltars[$altarPoint->x][$altarPoint->y] = $altarPoint;
+        $card = new LocateManaAltar();
+
+        $card->play($this->dungeon);
+
+        Assert::notNull($this->dungeon->tryTile($altarPoint));
+        $this->eventBus->assertDispatched(TileGenerated::class, function (TileGenerated $event) use ($altarPoint) {
+            Assert::true($event->tile->point->equals($altarPoint));
+        });
+    }
+
+    public function play_does_nothing_when_no_mana_altars_exist(): void
+    {
+        $this->dungeon->manaAltars = [];
+        $card = new LocateManaAltar();
+
+        $card->play($this->dungeon);
+
+        $this->eventBus->assertNotDispatched(TileGenerated::class);
+    }
+}

--- a/testo/Dungeon/Cards/LocateShardTest.php
+++ b/testo/Dungeon/Cards/LocateShardTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use Testo\Core\Exception\SkipTest;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class LocateShardTest extends DungeonTest
+{
+    public function play(): void
+    {
+        // TODO: LocateShard.play() is not yet implemented
+        throw new SkipTest('LocateShard is not yet implemented');
+    }
+}

--- a/testo/Dungeon/Cards/LocateStabilityAltarTest.php
+++ b/testo/Dungeon/Cards/LocateStabilityAltarTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\LocateStabilityAltar;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class LocateStabilityAltarTest extends DungeonTest
+{
+    public function play_generates_tile_at_undiscovered_stability_altar(): void
+    {
+        $altarPoint = new Point(5, 5);
+        $this->dungeon->stabilityAltars[$altarPoint->x][$altarPoint->y] = $altarPoint;
+        $card = new LocateStabilityAltar();
+
+        $card->play($this->dungeon);
+
+        Assert::notNull($this->dungeon->tryTile($altarPoint));
+        $this->eventBus->assertDispatched(TileGenerated::class, function (TileGenerated $event) use ($altarPoint) {
+            Assert::true($event->tile->point->equals($altarPoint));
+        });
+    }
+
+    public function play_does_nothing_when_no_stability_altars_exist(): void
+    {
+        $this->dungeon->stabilityAltars = [];
+        $card = new LocateStabilityAltar();
+
+        $card->play($this->dungeon);
+
+        $this->eventBus->assertNotDispatched(TileGenerated::class);
+    }
+}

--- a/testo/Dungeon/Cards/LocateVictoryPointTest.php
+++ b/testo/Dungeon/Cards/LocateVictoryPointTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use Testo\Core\Exception\SkipTest;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class LocateVictoryPointTest extends DungeonTest
+{
+    public function play(): void
+    {
+        // TODO: LocateVictoryPoint.play() is not yet implemented
+        throw new SkipTest('LocateVictoryPoint is not yet implemented');
+    }
+}

--- a/testo/Dungeon/Cards/ManaIncreaseMajorTest.php
+++ b/testo/Dungeon/Cards/ManaIncreaseMajorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\ManaIncreaseMajor;
+use App\Dungeon\Events\PlayerMaxManaIncreased;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class ManaIncreaseMajorTest extends DungeonTest
+{
+    public function play_increases_max_mana_by_50(): void
+    {
+        $maxManaBefore = $this->dungeon->maxMana;
+        $card = new ManaIncreaseMajor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->maxMana, $maxManaBefore + 50);
+        $this->eventBus->assertDispatched(PlayerMaxManaIncreased::class, function (PlayerMaxManaIncreased $event) {
+            Assert::same($event->amount, 50);
+        });
+    }
+}

--- a/testo/Dungeon/Cards/ManaIncreaseMinorTest.php
+++ b/testo/Dungeon/Cards/ManaIncreaseMinorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\ManaIncreaseMinor;
+use App\Dungeon\Events\PlayerMaxManaIncreased;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class ManaIncreaseMinorTest extends DungeonTest
+{
+    public function play_increases_max_mana_by_25(): void
+    {
+        $maxManaBefore = $this->dungeon->maxMana;
+        $card = new ManaIncreaseMinor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->maxMana, $maxManaBefore + 25);
+        $this->eventBus->assertDispatched(PlayerMaxManaIncreased::class, function (PlayerMaxManaIncreased $event) {
+            Assert::same($event->amount, 25);
+        });
+    }
+}

--- a/testo/Dungeon/Cards/ManaPerMoveMinorTest.php
+++ b/testo/Dungeon/Cards/ManaPerMoveMinorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\ManaPerMoveMinor;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PassiveCardUnset;
+use App\Dungeon\Events\PlayerManaIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class ManaPerMoveMinorTest extends DungeonTest
+{
+    public function handle_grants_10_mana_per_move(): void
+    {
+        $card = new ManaPerMoveMinor();
+        $this->dungeon->mana = 0;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        Assert::same($this->dungeon->mana, 10);
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class, function (PlayerManaIncreased $event) {
+            Assert::same($event->amount, 10);
+        });
+    }
+
+    public function handle_decrements_move_count(): void
+    {
+        $card = new ManaPerMoveMinor(); // moves = 10
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        Assert::same($card->moves, 9);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function handle_unsets_passive_card_when_moves_reach_zero(): void
+    {
+        $card = new ManaPerMoveMinor();
+        $card->moves = 1;
+        $this->dungeon->setPassiveCard($card);
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        Assert::same($card->moves, 0);
+        Assert::null($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PassiveCardUnset::class);
+    }
+
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new ManaPerMoveMinor();
+
+        $card->handle(
+            $this->dungeon,
+            new TileGenerated(
+                new Tile(new Point(1, 0)),
+            ),
+        );
+
+        Assert::same($card->moves, 10);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/testo/Dungeon/Cards/ManaPerMovePermanentTest.php
+++ b/testo/Dungeon/Cards/ManaPerMovePermanentTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\ManaPerMovePermanent;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerManaIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class ManaPerMovePermanentTest extends DungeonTest
+{
+    public function handle_grants_1_mana_per_move(): void
+    {
+        $card = new ManaPerMovePermanent();
+        $this->dungeon->mana = 0;
+
+        $card->handle($this->dungeon, new PlayerMoved(from: new Point(0, 0), to: new Point(1, 0)));
+
+        Assert::same($this->dungeon->mana, 1);
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class, function (PlayerManaIncreased $event) {
+            Assert::same($event->amount, 1);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new ManaPerMovePermanent();
+        $this->dungeon->mana = 0;
+
+        $card->handle(
+            $this->dungeon,
+            new TileGenerated(
+                new Tile(new Point(1, 0)),
+            ),
+        );
+
+        Assert::same($this->dungeon->mana, 0);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/testo/Dungeon/Cards/ProtectionMajorTest.php
+++ b/testo/Dungeon/Cards/ProtectionMajorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\ProtectionMajor;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PassiveCardUnset;
+use App\Dungeon\Events\PlayerHealthDecreased;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Point;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class ProtectionMajorTest extends DungeonTest
+{
+    public function handle_absorbs_damage_when_shield_has_enough(): void
+    {
+        $card = new ProtectionMajor(); // toAbsorb = 100
+        $this->dungeon->setPassiveCard($card);
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(30, 70, null));
+
+        Assert::same($card->toAbsorb, 70);
+        Assert::same($this->dungeon->health, 100);
+        Assert::notNull($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 30);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function handle_depletes_shield_and_unsets_passive_card_when_damage_exceeds_absorption(): void
+    {
+        $card = new ProtectionMajor();
+        $card->toAbsorb = 20;
+        $this->dungeon->setPassiveCard($card);
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(30, 70, null));
+
+        // Absorbs 20 (toAbsorb), not the full 30
+        Assert::same($this->dungeon->health, 90);
+        Assert::null($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PassiveCardUnset::class);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 20);
+        });
+    }
+
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new ProtectionMajor();
+
+        $card->handle($this->dungeon, new PlayerMoved(
+            from: new Point(0, 0),
+            to: new Point(1, 0),
+        ));
+
+        Assert::same($card->toAbsorb, 100);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/testo/Dungeon/Cards/ProtectionMinorTest.php
+++ b/testo/Dungeon/Cards/ProtectionMinorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\ProtectionMinor;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PassiveCardUnset;
+use App\Dungeon\Events\PlayerHealthDecreased;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Point;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class ProtectionMinorTest extends DungeonTest
+{
+    public function handle_absorbs_damage_when_shield_has_enough(): void
+    {
+        $card = new ProtectionMinor(); // toAbsorb = 50
+        $this->dungeon->setPassiveCard($card);
+        $this->dungeon->health = 80;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(20, 80, null));
+
+        Assert::same($card->toAbsorb, 30);
+        Assert::same($this->dungeon->health, 100);
+        Assert::notNull($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 20);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function handle_depletes_shield_and_unsets_passive_card_when_damage_exceeds_absorption(): void
+    {
+        $card = new ProtectionMinor();
+        $card->toAbsorb = 10;
+        $this->dungeon->setPassiveCard($card);
+        $this->dungeon->health = 70;
+
+        $card->handle($this->dungeon, new PlayerHealthDecreased(30, 70, null));
+
+        // Only absorbs 10 (toAbsorb)
+        Assert::same($this->dungeon->health, 80);
+        Assert::null($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PassiveCardUnset::class);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 10);
+        });
+    }
+
+    public function handle_ignores_unrelated_events(): void
+    {
+        $card = new ProtectionMinor();
+
+        $card->handle($this->dungeon, new PlayerMoved(
+            from: new Point(0, 0),
+            to: new Point(1, 0),
+        ));
+
+        Assert::same($card->toAbsorb, 50);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/testo/Dungeon/Cards/RumbleMajorTest.php
+++ b/testo/Dungeon/Cards/RumbleMajorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\RumbleMajor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerStabilityDecreased;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class RumbleMajorTest extends DungeonTest
+{
+    public function interact_with_tile_removes_collapse_and_decreases_stability(): void
+    {
+        $card = new RumbleMajor();
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->stability = 80;
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::false($tile->isCollapsed);
+        Assert::same($this->dungeon->stability, 70);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            Assert::same($event->amount, 10);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function interact_with_tile_unsets_active_card_after_three_uses(): void
+    {
+        $card = new RumbleMajor();
+        $this->dungeon->setActiveCard($card);
+
+        for ($i = 0; $i < 3; $i++) {
+            $tile = new Tile(new Point($i + 1, 0), isCollapsed: true);
+            $this->dungeon->addTile($tile);
+            $card->interactWithTile($this->dungeon, $tile);
+        }
+
+        Assert::null($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    public function can_interact_with_tile_returns_true_for_collapsed_tile(): void
+    {
+        $card = new RumbleMajor();
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+
+        Assert::true($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    public function can_interact_with_tile_returns_false_for_normal_tile(): void
+    {
+        $card = new RumbleMajor();
+        $tile = new Tile(new Point(1, 0));
+
+        Assert::false($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/testo/Dungeon/Cards/RumbleMinorTest.php
+++ b/testo/Dungeon/Cards/RumbleMinorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\RumbleMinor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerStabilityDecreased;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class RumbleMinorTest extends DungeonTest
+{
+    public function interact_with_tile_removes_collapse_decreases_stability_and_unsets_active_card(): void
+    {
+        $card = new RumbleMinor();
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+        $this->dungeon->addTile($tile);
+        $this->dungeon->stability = 80;
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::false($tile->isCollapsed);
+        Assert::same($this->dungeon->stability, 70);
+        Assert::null($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            Assert::same($event->amount, 10);
+        });
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function can_interact_with_tile_returns_true_for_collapsed_tile(): void
+    {
+        $card = new RumbleMinor();
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+
+        Assert::true($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    public function can_interact_with_tile_returns_false_for_normal_tile(): void
+    {
+        $card = new RumbleMinor();
+        $tile = new Tile(new Point(1, 0));
+
+        Assert::false($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/testo/Dungeon/Cards/StabilityMajorTest.php
+++ b/testo/Dungeon/Cards/StabilityMajorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\StabilityMajor;
+use App\Dungeon\Events\PlayerStabilityIncreased;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class StabilityMajorTest extends DungeonTest
+{
+    public function play_increases_stability_by_50(): void
+    {
+        $this->dungeon->stability = 30;
+        $card = new StabilityMajor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->stability, 80);
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            Assert::same($event->amount, 50);
+        });
+    }
+
+    public function play_is_capped_at_max_stability(): void
+    {
+        $this->dungeon->stability = 80;
+        $card = new StabilityMajor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->stability, 100);
+    }
+}

--- a/testo/Dungeon/Cards/StabilityMinorTest.php
+++ b/testo/Dungeon/Cards/StabilityMinorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\StabilityMinor;
+use App\Dungeon\Events\PlayerStabilityIncreased;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class StabilityMinorTest extends DungeonTest
+{
+    public function play_increases_stability_by_25(): void
+    {
+        $this->dungeon->stability = 30;
+        $card = new StabilityMinor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->stability, 55);
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            Assert::same($event->amount, 25);
+        });
+    }
+
+    public function play_is_capped_at_max_stability(): void
+    {
+        $this->dungeon->stability = 90;
+        $card = new StabilityMinor();
+
+        $card->play($this->dungeon);
+
+        Assert::same($this->dungeon->stability, 100);
+    }
+}

--- a/testo/Dungeon/Cards/StabilityPerTilePermanentTest.php
+++ b/testo/Dungeon/Cards/StabilityPerTilePermanentTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\StabilityPerTilePermanent;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Events\PlayerStabilityIncreased;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class StabilityPerTilePermanentTest extends DungeonTest
+{
+    public function handle_grants_1_stability_per_tile_generated(): void
+    {
+        $this->dungeon->stability = 50;
+        $card = new StabilityPerTilePermanent();
+        $tile = new Tile(new Point(5, 5));
+
+        $card->handle($this->dungeon, new TileGenerated($tile));
+
+        Assert::same($this->dungeon->stability, 51);
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            Assert::same($event->amount, 1);
+        });
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function handle_ignores_unrelated_events(): void
+    {
+        $this->dungeon->stability = 50;
+        $card = new StabilityPerTilePermanent();
+
+        $card->handle($this->dungeon, new PlayerMoved(
+            from: new Point(0, 0),
+            to: new Point(1, 0),
+        ));
+
+        Assert::same($this->dungeon->stability, 50);
+        $this->eventBus->assertNotDispatched(CardUpdated::class);
+    }
+}

--- a/testo/Dungeon/Cards/SupportEpicTest.php
+++ b/testo/Dungeon/Cards/SupportEpicTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use Testo\Core\Exception\SkipTest;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class SupportEpicTest extends DungeonTest
+{
+    public function interact_with_tile(): void
+    {
+        // TODO: SupportEpic.interactWithTile() is not yet implemented
+        throw new SkipTest('SupportEpic is not yet implemented');
+    }
+}

--- a/testo/Dungeon/Cards/SupportMajorTest.php
+++ b/testo/Dungeon/Cards/SupportMajorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\SupportMajor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class SupportMajorTest extends DungeonTest
+{
+    public function interact_with_tile_marks_tile_as_supported(): void
+    {
+        $card = new SupportMajor();
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::true($tile->isSupported);
+        Assert::same($card->count, 24);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function interact_with_tile_unsets_active_card_when_count_reaches_zero(): void
+    {
+        $card = new SupportMajor();
+        $card->count = 1;
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::same($card->count, 0);
+        Assert::null($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    public function can_interact_with_tile_returns_false_for_collapsed_tile(): void
+    {
+        $card = new SupportMajor();
+        $tile = new Tile(new Point(1, 0), isCollapsed: true);
+
+        Assert::false($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    public function can_interact_with_tile_returns_false_for_already_supported_tile(): void
+    {
+        $card = new SupportMajor();
+        $tile = new Tile(new Point(1, 0), isSupported: true);
+
+        Assert::false($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    public function can_interact_with_tile_returns_false_for_origin_tile(): void
+    {
+        $card = new SupportMajor();
+        $tile = new Tile(new Point(0, 0), isOrigin: true);
+
+        Assert::false($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    public function can_interact_with_tile_returns_true_for_normal_tile(): void
+    {
+        $card = new SupportMajor();
+        $tile = new Tile(new Point(1, 0));
+
+        Assert::true($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/testo/Dungeon/Cards/SupportMinorTest.php
+++ b/testo/Dungeon/Cards/SupportMinorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\SupportMinor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class SupportMinorTest extends DungeonTest
+{
+    public function interact_with_tile_marks_tile_as_supported(): void
+    {
+        $card = new SupportMinor();
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::true($tile->isSupported);
+        Assert::same($card->count, 9);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function interact_with_tile_unsets_active_card_when_count_reaches_zero(): void
+    {
+        $card = new SupportMinor();
+        $card->count = 1;
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0));
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::same($card->count, 0);
+        Assert::null($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    public function can_interact_with_tile_returns_false_for_trapped_tile(): void
+    {
+        $card = new SupportMinor();
+        $tile = new Tile(new Point(1, 0), isTrapped: true);
+
+        Assert::false($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    public function can_interact_with_tile_returns_true_for_normal_tile(): void
+    {
+        $card = new SupportMinor();
+        $tile = new Tile(new Point(1, 0));
+
+        Assert::true($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/testo/Dungeon/Cards/TokenTest.php
+++ b/testo/Dungeon/Cards/TokenTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\Token;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class TokenTest extends DungeonTest
+{
+    public function play_does_nothing(): void
+    {
+        $card = new Token();
+
+        $card->play($this->dungeon);
+
+        // Token is a META card — it grants a token when purchased from the shop;
+        // playing it in-game has no effect.
+        Assert::true($this->dungeon->hasEnded === false);
+    }
+}

--- a/testo/Dungeon/Cards/TrapDisarmMajorTest.php
+++ b/testo/Dungeon/Cards/TrapDisarmMajorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\TrapDisarmMajor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class TrapDisarmMajorTest extends DungeonTest
+{
+    public function interact_with_tile_removes_trap(): void
+    {
+        $card = new TrapDisarmMajor();
+        $tile = new Tile(new Point(1, 0), isTrapped: true);
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::false($tile->isTrapped);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function interact_with_tile_unsets_active_card_after_three_uses(): void
+    {
+        $card = new TrapDisarmMajor();
+        $this->dungeon->setActiveCard($card);
+
+        for ($i = 0; $i < 3; $i++) {
+            $tile = new Tile(new Point($i + 1, 0), isTrapped: true);
+            $this->dungeon->addTile($tile);
+            $card->interactWithTile($this->dungeon, $tile);
+        }
+
+        Assert::null($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    public function interact_with_tile_does_not_unset_card_before_three_uses(): void
+    {
+        $card = new TrapDisarmMajor();
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0), isTrapped: true);
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::notNull($this->dungeon->activeCard);
+        $this->eventBus->assertNotDispatched(ActiveCardUnset::class);
+    }
+
+    public function can_interact_with_tile_returns_true_for_trapped_tile(): void
+    {
+        $card = new TrapDisarmMajor();
+        $tile = new Tile(new Point(1, 0), isTrapped: true);
+
+        Assert::true($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    public function can_interact_with_tile_returns_false_for_non_trapped_tile(): void
+    {
+        $card = new TrapDisarmMajor();
+        $tile = new Tile(new Point(1, 0));
+
+        Assert::false($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/testo/Dungeon/Cards/TrapDisarmMinorTest.php
+++ b/testo/Dungeon/Cards/TrapDisarmMinorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\TrapDisarmMinor;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class TrapDisarmMinorTest extends DungeonTest
+{
+    public function interact_with_tile_removes_trap_and_unsets_active_card(): void
+    {
+        $card = new TrapDisarmMinor();
+        $this->dungeon->setActiveCard($card);
+        $tile = new Tile(new Point(1, 0), isTrapped: true);
+        $this->dungeon->addTile($tile);
+
+        $card->interactWithTile($this->dungeon, $tile);
+
+        Assert::false($tile->isTrapped);
+        Assert::null($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+        $this->eventBus->assertDispatched(CardUpdated::class);
+    }
+
+    public function can_interact_with_tile_returns_true_for_trapped_tile(): void
+    {
+        $card = new TrapDisarmMinor();
+        $tile = new Tile(new Point(1, 0), isTrapped: true);
+
+        Assert::true($card->canInteractWithTile($this->dungeon, $tile));
+    }
+
+    public function can_interact_with_tile_returns_false_for_non_trapped_tile(): void
+    {
+        $card = new TrapDisarmMinor();
+        $tile = new Tile(new Point(1, 0));
+
+        Assert::false($card->canInteractWithTile($this->dungeon, $tile));
+    }
+}

--- a/testo/Dungeon/Cards/UpperHandMajorTest.php
+++ b/testo/Dungeon/Cards/UpperHandMajorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\UpperHandMajor;
+use App\Dungeon\Events\DwellerDespawned;
+use App\Dungeon\Events\DwellerSpawned;
+use App\Dungeon\Point;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class UpperHandMajorTest extends DungeonTest
+{
+    public function play_despawns_all_visible_dwellers(): void
+    {
+        $this->dungeon->dwellers = [];
+        // Spawn within visibility radius (default 5, player at origin)
+        $this->dungeon->spawnDweller(new Point(2, 0));
+        $this->dungeon->spawnDweller(new Point(3, 0));
+        $card = new UpperHandMajor();
+
+        $card->play($this->dungeon);
+
+        Assert::null($this->dungeon->getDweller(new Point(2, 0)));
+        Assert::null($this->dungeon->getDweller(new Point(3, 0)));
+        $this->eventBus->assertDispatched(DwellerDespawned::class);
+    }
+
+    public function play_spawns_a_new_dweller_for_each_despawned(): void
+    {
+        $this->dungeon->dwellers = [];
+        $this->dungeon->spawnDweller(new Point(2, 0));
+        $this->dungeon->spawnDweller(new Point(3, 0));
+        $dwellerCountBefore = iterator_count($this->dungeon->loopDwellers());
+        $card = new UpperHandMajor();
+
+        $card->play($this->dungeon);
+
+        Assert::same(iterator_count($this->dungeon->loopDwellers()), $dwellerCountBefore);
+        $this->eventBus->assertDispatched(DwellerSpawned::class);
+    }
+
+    public function can_play_returns_true_when_visible_dwellers_exist(): void
+    {
+        $this->dungeon->dwellers = [];
+        $this->dungeon->spawnDweller(new Point(2, 0));
+        $card = new UpperHandMajor();
+
+        Assert::true($card->canPlay($this->dungeon));
+    }
+
+    public function can_play_returns_false_when_no_visible_dwellers(): void
+    {
+        $this->dungeon->dwellers = [];
+        $card = new UpperHandMajor();
+
+        Assert::false($card->canPlay($this->dungeon));
+    }
+}

--- a/testo/Dungeon/Cards/UpperHandMinorTest.php
+++ b/testo/Dungeon/Cards/UpperHandMinorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\UpperHandMinor;
+use App\Dungeon\Events\DwellerDespawned;
+use App\Dungeon\Events\DwellerSpawned;
+use App\Dungeon\Point;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class UpperHandMinorTest extends DungeonTest
+{
+    public function play_despawns_one_visible_dweller(): void
+    {
+        $this->dungeon->dwellers = [];
+        $this->dungeon->spawnDweller(new Point(2, 0));
+        $card = new UpperHandMinor();
+
+        $card->play($this->dungeon);
+
+        // One despawned, one spawned — total stays at 1
+        Assert::same(iterator_count($this->dungeon->loopDwellers()), 1);
+        $this->eventBus->assertDispatched(DwellerDespawned::class);
+    }
+
+    public function play_spawns_a_new_dweller(): void
+    {
+        $this->dungeon->dwellers = [];
+        $this->dungeon->spawnDweller(new Point(2, 0));
+        $card = new UpperHandMinor();
+
+        $card->play($this->dungeon);
+
+        // Total count stays the same: 1 despawned, 1 spawned
+        Assert::same(iterator_count($this->dungeon->loopDwellers()), 1);
+        $this->eventBus->assertDispatched(DwellerSpawned::class);
+    }
+
+    public function can_play_returns_true_when_visible_dwellers_exist(): void
+    {
+        $this->dungeon->dwellers = [];
+        $this->dungeon->spawnDweller(new Point(2, 0));
+        $card = new UpperHandMinor();
+
+        Assert::true($card->canPlay($this->dungeon));
+    }
+
+    public function can_play_returns_false_when_no_visible_dwellers(): void
+    {
+        $this->dungeon->dwellers = [];
+        $card = new UpperHandMinor();
+
+        Assert::false($card->canPlay($this->dungeon));
+    }
+}

--- a/testo/Dungeon/Cards/VictoryPointTest.php
+++ b/testo/Dungeon/Cards/VictoryPointTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\Cards;
+
+use App\Dungeon\Cards\VictoryPoint;
+use Testo\Assert;
+use Testo\Test;
+use Tests\Testo\Dungeon\DungeonTest;
+
+#[Test]
+final class VictoryPointTest extends DungeonTest
+{
+    public function play_does_nothing(): void
+    {
+        $card = new VictoryPoint();
+
+        $card->play($this->dungeon);
+
+        // VictoryPoint is a META card — it grants a VP when purchased from the shop;
+        // playing it in-game has no effect.
+        Assert::true($this->dungeon->hasEnded === false);
+    }
+}

--- a/testo/Dungeon/DeckValidators/BreakthroughDeckValidatorTest.php
+++ b/testo/Dungeon/DeckValidators/BreakthroughDeckValidatorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\BreakthroughMajor;
+use App\Dungeon\Cards\BreakthroughMinor;
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\DeckValidators\BreakthroughDeckValidator;
+use Tempest\Support\Arr\ImmutableArray;
+use Testo\Assert;
+use Testo\Test;
+
+#[Test]
+final class BreakthroughDeckValidatorTest
+{
+    public function validate_returns_null_for_non_breakthrough_card(): void
+    {
+        $validator = new BreakthroughDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new BreakthroughMinor()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_null_when_deck_has_fewer_than_5_breakthrough_cards(): void
+    {
+        $validator = new BreakthroughDeckValidator();
+        $deck = new ImmutableArray([
+            new BreakthroughMinor(),
+            new BreakthroughMajor(),
+            new BreakthroughMinor(),
+            new BreakthroughMajor(),
+        ]);
+
+        $result = $validator->validate(new BreakthroughMinor(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_failure_when_deck_already_has_5_breakthrough_cards(): void
+    {
+        $validator = new BreakthroughDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new BreakthroughMinor()));
+
+        $result = $validator->validate(new BreakthroughMajor(), $deck);
+
+        Assert::notNull($result);
+        Assert::same($result->message, 'You can only have 5 breakthrough cards in your deck');
+    }
+}

--- a/testo/Dungeon/DeckValidators/ClarityDeckValidatorTest.php
+++ b/testo/Dungeon/DeckValidators/ClarityDeckValidatorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\Clarity;
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\DeckValidators\ClarityDeckValidator;
+use Tempest\Support\Arr\ImmutableArray;
+use Testo\Assert;
+use Testo\Test;
+
+#[Test]
+final class ClarityDeckValidatorTest
+{
+    public function validate_returns_null_for_non_clarity_card(): void
+    {
+        $validator = new ClarityDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 3, new Clarity()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_null_when_deck_has_fewer_than_3_clarity_cards(): void
+    {
+        $validator = new ClarityDeckValidator();
+        $deck = new ImmutableArray([new Clarity(), new Clarity()]);
+
+        $result = $validator->validate(new Clarity(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_failure_when_deck_already_has_3_clarity_cards(): void
+    {
+        $validator = new ClarityDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 3, new Clarity()));
+
+        $result = $validator->validate(new Clarity(), $deck);
+
+        Assert::notNull($result);
+        Assert::same($result->message, 'You can only have 3 clarity cards in your deck');
+    }
+}

--- a/testo/Dungeon/DeckValidators/CompoundDeckValidatorTest.php
+++ b/testo/Dungeon/DeckValidators/CompoundDeckValidatorTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\DeckValidators;
+
+use App\Dungeon\Card;
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\DeckValidationFailed;
+use App\Dungeon\DeckValidator;
+use App\Dungeon\DeckValidators\CompoundDeckValidator;
+use Tempest\Support\Arr\ImmutableArray;
+use Testo\Assert;
+use Testo\Test;
+
+#[Test]
+final class CompoundDeckValidatorTest
+{
+    public function validate_returns_null_when_all_validators_pass(): void
+    {
+        $compound = new CompoundDeckValidator();
+        $compound->addValidator(new class implements DeckValidator {
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                return null;
+            }
+        });
+        $compound->addValidator(new class implements DeckValidator {
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                return null;
+            }
+        });
+
+        $result = $compound->validate(new HealMinor(), new ImmutableArray([]));
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_first_failure(): void
+    {
+        $compound = new CompoundDeckValidator();
+        $compound->addValidator(new class implements DeckValidator {
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                return new DeckValidationFailed('First failure');
+            }
+        });
+        $compound->addValidator(new class implements DeckValidator {
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                return new DeckValidationFailed('Second failure');
+            }
+        });
+
+        $result = $compound->validate(new HealMinor(), new ImmutableArray([]));
+
+        Assert::notNull($result);
+        Assert::same($result->message, 'First failure');
+    }
+
+    public function validate_stops_at_first_failure_and_skips_remaining_validators(): void
+    {
+        $compound = new CompoundDeckValidator();
+        $compound->addValidator(new class implements DeckValidator {
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                return null;
+            }
+        });
+        $compound->addValidator(new class implements DeckValidator {
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                return new DeckValidationFailed('Blocking failure');
+            }
+        });
+        $spy = new class implements DeckValidator {
+            public bool $reached = false;
+
+            public function validate(Card $card, ImmutableArray $deck): ?DeckValidationFailed
+            {
+                $this->reached = true;
+
+                return null;
+            }
+        };
+        $compound->addValidator($spy);
+
+        $compound->validate(new HealMinor(), new ImmutableArray([]));
+
+        Assert::false($spy->reached);
+    }
+}

--- a/testo/Dungeon/DeckValidators/DeckSizeValidatorTest.php
+++ b/testo/Dungeon/DeckValidators/DeckSizeValidatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\DeckValidators\DeckSizeValidator;
+use Tempest\Support\Arr\ImmutableArray;
+use Testo\Assert;
+use Testo\Test;
+
+#[Test]
+final class DeckSizeValidatorTest
+{
+    public function validate_returns_null_when_deck_has_fewer_than_20_cards(): void
+    {
+        $validator = new DeckSizeValidator();
+        $deck = new ImmutableArray(array_fill(0, 19, new HealMinor()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_failure_when_deck_has_20_cards(): void
+    {
+        $validator = new DeckSizeValidator();
+        $deck = new ImmutableArray(array_fill(0, 20, new HealMinor()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        Assert::notNull($result);
+        Assert::same($result->message, 'Your deck is full');
+    }
+}

--- a/testo/Dungeon/DeckValidators/LocateDeckValidatorTest.php
+++ b/testo/Dungeon/DeckValidators/LocateDeckValidatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\Cards\LocateHealthAltar;
+use App\Dungeon\Cards\LocateManaAltar;
+use App\Dungeon\Cards\LocateStabilityAltar;
+use App\Dungeon\DeckValidators\LocateDeckValidator;
+use Tempest\Support\Arr\ImmutableArray;
+use Testo\Assert;
+use Testo\Test;
+
+#[Test]
+final class LocateDeckValidatorTest
+{
+    public function validate_returns_null_for_non_locate_card(): void
+    {
+        $validator = new LocateDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 3, new LocateHealthAltar()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_null_when_deck_has_fewer_than_3_locate_cards(): void
+    {
+        $validator = new LocateDeckValidator();
+        $deck = new ImmutableArray([
+            new LocateHealthAltar(),
+            new LocateManaAltar(),
+        ]);
+
+        $result = $validator->validate(new LocateStabilityAltar(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_failure_when_deck_already_has_3_locate_cards(): void
+    {
+        $validator = new LocateDeckValidator();
+        $deck = new ImmutableArray([
+            new LocateHealthAltar(),
+            new LocateManaAltar(),
+            new LocateStabilityAltar(),
+        ]);
+
+        $result = $validator->validate(new LocateHealthAltar(), $deck);
+
+        Assert::notNull($result);
+        Assert::same($result->message, 'You can only have 3 locate cards in your deck');
+    }
+}

--- a/testo/Dungeon/DeckValidators/PermanentCardDeckValidatorTest.php
+++ b/testo/Dungeon/DeckValidators/PermanentCardDeckValidatorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\ChestplateMajorPermanent;
+use App\Dungeon\Cards\ChestplateMinorPermanent;
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\Cards\ManaPerMovePermanent;
+use App\Dungeon\DeckValidators\PermanentCardDeckValidator;
+use Tempest\Support\Arr\ImmutableArray;
+use Testo\Assert;
+use Testo\Test;
+
+#[Test]
+final class PermanentCardDeckValidatorTest
+{
+    public function validate_returns_null_for_non_permanent_card(): void
+    {
+        $validator = new PermanentCardDeckValidator();
+        $deck = new ImmutableArray([
+            new ChestplateMinorPermanent(),
+            new ChestplateMinorPermanent(),
+            new ChestplateMinorPermanent(),
+        ]);
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_null_when_deck_has_fewer_than_3_permanent_cards(): void
+    {
+        $validator = new PermanentCardDeckValidator();
+        $deck = new ImmutableArray([
+            new ChestplateMinorPermanent(),
+            new ChestplateMajorPermanent(),
+        ]);
+
+        $result = $validator->validate(new ManaPerMovePermanent(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_failure_when_deck_already_has_3_permanent_cards(): void
+    {
+        $validator = new PermanentCardDeckValidator();
+        $deck = new ImmutableArray([
+            new ChestplateMinorPermanent(),
+            new ChestplateMajorPermanent(),
+            new ManaPerMovePermanent(),
+        ]);
+
+        $result = $validator->validate(new ChestplateMinorPermanent(), $deck);
+
+        Assert::notNull($result);
+        Assert::same($result->message, 'You can only have 3 permanent cards in your deck');
+    }
+}

--- a/testo/Dungeon/DeckValidators/RumbleDeckValidatorTest.php
+++ b/testo/Dungeon/DeckValidators/RumbleDeckValidatorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\Cards\RumbleMajor;
+use App\Dungeon\Cards\RumbleMinor;
+use App\Dungeon\DeckValidators\RumbleDeckValidator;
+use Tempest\Support\Arr\ImmutableArray;
+use Testo\Assert;
+use Testo\Test;
+
+#[Test]
+final class RumbleDeckValidatorTest
+{
+    public function validate_returns_null_for_non_rumble_card(): void
+    {
+        $validator = new RumbleDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new RumbleMinor()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_null_for_rumble_major(): void
+    {
+        // RumbleDeckValidator only checks RumbleMinor; RumbleMajor is not restricted
+        $validator = new RumbleDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new RumbleMinor()));
+
+        $result = $validator->validate(new RumbleMajor(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_null_when_deck_has_fewer_than_5_rumble_minor_cards(): void
+    {
+        $validator = new RumbleDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 4, new RumbleMinor()));
+
+        $result = $validator->validate(new RumbleMinor(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_failure_when_deck_already_has_5_rumble_minor_cards(): void
+    {
+        $validator = new RumbleDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new RumbleMinor()));
+
+        $result = $validator->validate(new RumbleMinor(), $deck);
+
+        Assert::notNull($result);
+        Assert::same($result->message, 'You can only have 5 rumble cards in your deck');
+    }
+}

--- a/testo/Dungeon/DeckValidators/StabilityDeckValidatorTest.php
+++ b/testo/Dungeon/DeckValidators/StabilityDeckValidatorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\Cards\StabilityMajor;
+use App\Dungeon\Cards\StabilityMinor;
+use App\Dungeon\DeckValidators\StabilityDeckValidator;
+use Tempest\Support\Arr\ImmutableArray;
+use Testo\Assert;
+use Testo\Test;
+
+#[Test]
+final class StabilityDeckValidatorTest
+{
+    public function validate_returns_null_for_non_stability_card(): void
+    {
+        $validator = new StabilityDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 7, new StabilityMinor()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_null_when_deck_has_fewer_than_7_stability_cards(): void
+    {
+        $validator = new StabilityDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 6, new StabilityMinor()));
+
+        $result = $validator->validate(new StabilityMajor(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_failure_when_deck_already_has_7_stability_cards(): void
+    {
+        $validator = new StabilityDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 7, new StabilityMinor()));
+
+        $result = $validator->validate(new StabilityMajor(), $deck);
+
+        Assert::notNull($result);
+        Assert::same($result->message, 'You can only have 7 stability cards in your deck');
+    }
+}

--- a/testo/Dungeon/DeckValidators/SupportDeckValidatorTest.php
+++ b/testo/Dungeon/DeckValidators/SupportDeckValidatorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon\DeckValidators;
+
+use App\Dungeon\Cards\HealMinor;
+use App\Dungeon\Cards\SupportMajor;
+use App\Dungeon\Cards\SupportMinor;
+use App\Dungeon\DeckValidators\SupportDeckValidator;
+use Tempest\Support\Arr\ImmutableArray;
+use Testo\Assert;
+use Testo\Test;
+
+#[Test]
+final class SupportDeckValidatorTest
+{
+    public function validate_returns_null_for_non_support_card(): void
+    {
+        $validator = new SupportDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new SupportMinor()));
+
+        $result = $validator->validate(new HealMinor(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_null_when_deck_has_fewer_than_5_support_cards(): void
+    {
+        $validator = new SupportDeckValidator();
+        $deck = new ImmutableArray([
+            new SupportMinor(),
+            new SupportMajor(),
+            new SupportMinor(),
+            new SupportMajor(),
+        ]);
+
+        $result = $validator->validate(new SupportMinor(), $deck);
+
+        Assert::null($result);
+    }
+
+    public function validate_returns_failure_when_deck_already_has_5_support_cards(): void
+    {
+        $validator = new SupportDeckValidator();
+        $deck = new ImmutableArray(array_fill(0, 5, new SupportMinor()));
+
+        $result = $validator->validate(new SupportMajor(), $deck);
+
+        Assert::notNull($result);
+        Assert::same($result->message, 'You can only have 5 support cards in your deck');
+    }
+}

--- a/testo/Dungeon/DungeonActionsTest.php
+++ b/testo/Dungeon/DungeonActionsTest.php
@@ -1,0 +1,1410 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon;
+
+use App\Dungeon\Cards\BeaconMinor;
+use App\Dungeon\Direction;
+use App\Dungeon\Events\ActiveCardSet;
+use App\Dungeon\Events\ActiveCardUnset;
+use App\Dungeon\Events\ArtifactCollected;
+use App\Dungeon\Events\ArtifactSpawned;
+use App\Dungeon\Events\CardDrawn;
+use App\Dungeon\Events\CardPlayed;
+use App\Dungeon\Events\CardUpdated;
+use App\Dungeon\Events\DwellerDespawned;
+use App\Dungeon\Events\DwellerMoved;
+use App\Dungeon\Events\DwellerSpawned;
+use App\Dungeon\Events\DwellerUpdated;
+use App\Dungeon\Events\LakeDiscovered;
+use App\Dungeon\Events\PassiveCardSet;
+use App\Dungeon\Events\PassiveCardUnset;
+use App\Dungeon\Events\PermanentCardAdded;
+use App\Dungeon\Events\PlayerCoinsIncreased;
+use App\Dungeon\Events\PlayerExited;
+use App\Dungeon\Events\PlayerHealthDecreased;
+use App\Dungeon\Events\PlayerHealthIncreased;
+use App\Dungeon\Events\PlayerManaDecreased;
+use App\Dungeon\Events\PlayerManaIncreased;
+use App\Dungeon\Events\PlayerMaxHealthIncreased;
+use App\Dungeon\Events\PlayerMaxManaIncreased;
+use App\Dungeon\Events\PlayerMoved;
+use App\Dungeon\Events\PlayerResigned;
+use App\Dungeon\Events\PlayerShardsIncreased;
+use App\Dungeon\Events\PlayerStabilityDecreased;
+use App\Dungeon\Events\PlayerStabilityIncreased;
+use App\Dungeon\Events\PlayerVictoryPointsIncreased;
+use App\Dungeon\Events\RelicCollected;
+use App\Dungeon\Events\TileCoinsAdded;
+use App\Dungeon\Events\TileCoinsCollected;
+use App\Dungeon\Events\TileCollapsed;
+use App\Dungeon\Events\TileGenerated;
+use App\Dungeon\Events\TileUpdated;
+use App\Dungeon\Events\VisibilityChanged;
+use App\Dungeon\Lake;
+use App\Dungeon\LakePoint;
+use App\Dungeon\Listeners\PlayerMovementListener;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Core\Exception\SkipTest;
+use Testo\Test;
+
+#[Test]
+final class DungeonActionsTest extends DungeonTest
+{
+    // -------------------------------------------------------------------------
+    // generateTile
+    // -------------------------------------------------------------------------
+
+    public function generate_tile_adds_new_tile(): void
+    {
+        $point = new Point(x: 1, y: 1);
+
+        $this->dungeon->generateTile(from: null, to: $point);
+
+        Assert::notNull($this->dungeon->tryTile($point));
+
+        $this->eventBus->assertDispatched(TileGenerated::class, function (TileGenerated $event) use ($point) {
+            Assert::true($event->tile->point->equals($point));
+        });
+    }
+
+    public function generate_tile_does_not_overwrite_existing_tile(): void
+    {
+        $point = new Point(0, 0); // origin tile already exists
+
+        $tileCountBefore = $this->dungeon->tileCount();
+
+        $this->dungeon->generateTile(from: null, to: $point);
+
+        Assert::same($this->dungeon->tileCount(), $tileCountBefore);
+        $this->eventBus->assertNotDispatched(TileGenerated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // move
+    // -------------------------------------------------------------------------
+
+    public function move_updates_player_position(): void
+    {
+        $this->dungeon->move(Direction::RIGHT);
+
+        Assert::true($this->dungeon->playerPosition->equals(new Point(1, 0)));
+
+        $this->eventBus->assertDispatched(PlayerMoved::class, function (PlayerMoved $event) {
+            Assert::true($event->from->equals(new Point(0, 0)));
+            Assert::true($event->to->equals(new Point(1, 0)));
+        });
+    }
+
+    public function move_generates_new_tile_when_no_tile_exists_at_destination(): void
+    {
+        Assert::null($this->dungeon->tryTile(new Point(1, 0)));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        Assert::notNull($this->dungeon->tryTile(new Point(1, 0)));
+        $this->eventBus->assertDispatched(TileGenerated::class);
+    }
+
+    public function move_does_not_move_when_current_tile_has_no_opening_in_that_direction(): void
+    {
+        $this->dungeon->addTile(new Tile(new Point(0, 0), directions: [Direction::TOP, Direction::BOTTOM], isOrigin: true));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        Assert::true($this->dungeon->playerPosition->equals(new Point(0, 0)));
+        $this->eventBus->assertNotDispatched(PlayerMoved::class);
+    }
+
+    public function move_does_not_move_into_collapsed_tile(): void
+    {
+        $this->dungeon->addTile(new Tile(new Point(1, 0), isCollapsed: true));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        Assert::true($this->dungeon->playerPosition->equals(new Point(0, 0)));
+        $this->eventBus->assertNotDispatched(PlayerMoved::class);
+    }
+
+    public function move_does_not_move_when_neighbour_tile_has_no_opening_on_its_entry_side(): void
+    {
+        $this->dungeon->addTile(new Tile(new Point(1, 0), directions: [Direction::RIGHT, Direction::TOP, Direction::BOTTOM]));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        Assert::true($this->dungeon->playerPosition->equals(new Point(0, 0)));
+        $this->eventBus->assertNotDispatched(PlayerMoved::class);
+    }
+
+    public function move_does_not_move_onto_lake_tile(): void
+    {
+        $this->dungeon->addTile(new Tile(new Point(1, 0), isLake: true));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        Assert::true($this->dungeon->playerPosition->equals(new Point(0, 0)));
+        $this->eventBus->assertNotDispatched(PlayerMoved::class);
+    }
+
+    public function move_can_move_onto_lake_tile_when_can_walk_on_water(): void
+    {
+        $this->dungeon->addTile(new Tile(new Point(1, 0), isLake: true));
+        $this->dungeon->canWalkOnWater = true;
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        Assert::true($this->dungeon->playerPosition->equals(new Point(1, 0)));
+        $this->eventBus->assertDispatched(PlayerMoved::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // generateTile (lake)
+    // -------------------------------------------------------------------------
+
+    public function generate_tile_on_lake_point_marks_tile_as_lake(): void
+    {
+        $lakePoint = new Point(5, 5);
+        $lake = new Lake($lakePoint);
+        $lake->addLakePoint(new LakePoint($lakePoint, depth: 2));
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $lakePoint);
+
+        $tile = $this->dungeon->tryTile($lakePoint);
+        Assert::true($tile->isLake);
+        Assert::same($tile->depth, 2);
+    }
+
+    public function generate_tile_on_lake_point_opens_all_directions(): void
+    {
+        $lakePoint = new Point(5, 5);
+        $lake = new Lake($lakePoint);
+        $lake->addLakePoint(new LakePoint($lakePoint, depth: 1));
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $lakePoint);
+
+        $tile = $this->dungeon->tryTile($lakePoint);
+        Assert::same($tile->directions, Direction::cases());
+    }
+
+    public function generate_tile_on_lake_relic_point_marks_tile_as_relic(): void
+    {
+        $lakePoint = new Point(5, 5);
+        $lake = new Lake($lakePoint);
+        $lake->addLakePoint(new LakePoint($lakePoint, depth: 3));
+        $lake->relic = $lakePoint;
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $lakePoint);
+
+        $tile = $this->dungeon->tryTile($lakePoint);
+        Assert::true($tile->isLake);
+        Assert::true($tile->isRelic);
+    }
+
+    public function generate_tile_on_non_relic_lake_point_does_not_mark_tile_as_relic(): void
+    {
+        $lakePoint = new Point(5, 5);
+        $relicPoint = new Point(6, 5);
+        $lake = new Lake($lakePoint);
+        $lake->addLakePoint(new LakePoint($lakePoint, depth: 3));
+        $lake->relic = $relicPoint;
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $lakePoint);
+
+        $tile = $this->dungeon->tryTile($lakePoint);
+        Assert::false($tile->isRelic);
+    }
+
+    public function generate_tile_on_lake_edge_opens_all_directions(): void
+    {
+        $origin = new Point(5, 5);
+        $edgePoint = new Point(5, 4);
+        $lake = new Lake($origin);
+        $lake->addEdge($edgePoint);
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $edgePoint);
+
+        $tile = $this->dungeon->tryTile($edgePoint);
+        Assert::false($tile->isLake);
+        Assert::same($tile->directions, Direction::cases());
+    }
+
+    public function generate_tile_on_lake_edge_dispatches_lake_discovered(): void
+    {
+        $origin = new Point(5, 5);
+        $edgePoint = new Point(5, 4);
+        $lake = new Lake($origin);
+        $lake->addEdge($edgePoint);
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $edgePoint);
+
+        $this->eventBus->assertDispatched(LakeDiscovered::class, function (LakeDiscovered $event) use ($edgePoint) {
+            Assert::true($event->tile->point->equals($edgePoint));
+            Assert::true($event->lake->isDiscovered);
+        });
+    }
+
+    public function generate_tile_on_already_discovered_lake_edge_does_not_dispatch_lake_discovered(): void
+    {
+        $origin = new Point(5, 5);
+        $edgePoint = new Point(5, 4);
+        $lake = new Lake($origin, isDiscovered: true);
+        $lake->addEdge($edgePoint);
+        $this->dungeon->lakes[] = $lake;
+
+        $this->dungeon->generateTile(from: null, to: $edgePoint);
+
+        $this->eventBus->assertNotDispatched(LakeDiscovered::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // collectRelic
+    // -------------------------------------------------------------------------
+
+    public function collect_relic_marks_tile_as_not_relic(): void
+    {
+        $tile = new Tile(new Point(1, 0), isRelic: true);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collectRelic($tile);
+
+        Assert::false($tile->isRelic);
+    }
+
+    public function collect_relic_dispatches_relic_collected_event(): void
+    {
+        $tile = new Tile(new Point(1, 0), isRelic: true);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collectRelic($tile);
+
+        $this->eventBus->assertDispatched(RelicCollected::class, function (RelicCollected $event) use ($tile) {
+            Assert::true($event->tile->point->equals($tile->point));
+        });
+    }
+
+    public function collect_relic_increases_coins(): void
+    {
+        $tile = new Tile(new Point(1, 0), isRelic: true);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collectRelic($tile);
+
+        Assert::int($this->dungeon->coins)->greaterThan(0);
+    }
+
+    public function collect_relic_increases_mana(): void
+    {
+        $tile = new Tile(new Point(1, 0), isRelic: true);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collectRelic($tile);
+
+        Assert::int($this->dungeon->mana)->greaterThan(0);
+    }
+
+    public function collect_relic_does_nothing_when_tile_is_not_relic(): void
+    {
+        $tile = new Tile(new Point(1, 0), isRelic: false);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collectRelic($tile);
+
+        Assert::same($this->dungeon->coins, 0);
+        $this->eventBus->assertNotDispatched(RelicCollected::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // addCoinsToTile
+    // -------------------------------------------------------------------------
+
+    public function add_coins_to_tile(): void
+    {
+        $tile = $this->dungeon->currentTile;
+
+        $this->dungeon->addCoinsToTile($tile, 50);
+
+        Assert::same($tile->coins, 50);
+
+        $this->eventBus->assertDispatched(TileCoinsAdded::class, function (TileCoinsAdded $event) use ($tile) {
+            Assert::true($event->tile->point->equals($tile->point));
+            Assert::same($event->amount, 50);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // collectCoins
+    // -------------------------------------------------------------------------
+
+    public function collect_coins(): void
+    {
+        $tile = $this->dungeon->currentTile;
+        $tile->coins = 75;
+
+        $this->dungeon->collectCoins($tile);
+
+        Assert::same($this->dungeon->coins, 75);
+        Assert::same($tile->coins, 0);
+
+        $this->eventBus->assertDispatched(TileCoinsCollected::class, function (TileCoinsCollected $event) {
+            Assert::same($event->amount, 75);
+            Assert::same($event->total, 75);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseMaxMana
+    // -------------------------------------------------------------------------
+
+    public function increase_max_mana(): void
+    {
+        $this->dungeon->increaseMaxMana(50);
+
+        Assert::same($this->dungeon->maxMana, 200);
+
+        $this->eventBus->assertDispatched(PlayerMaxManaIncreased::class, function (PlayerMaxManaIncreased $event) {
+            Assert::same($event->amount, 50);
+            Assert::same($event->total, 200);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseMana / decreaseMana
+    // -------------------------------------------------------------------------
+
+    public function increase_mana(): void
+    {
+        $this->dungeon->increaseMana(30);
+
+        Assert::same($this->dungeon->mana, 30);
+
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class, function (PlayerManaIncreased $event) {
+            Assert::same($event->amount, 30);
+            Assert::same($event->total, 30);
+        });
+    }
+
+    public function increase_mana_is_capped_at_max_mana(): void
+    {
+        $this->dungeon->increaseMana(200); // maxMana is 150
+
+        Assert::same($this->dungeon->mana, 150);
+
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class, function (PlayerManaIncreased $event) {
+            Assert::same($event->amount, 150);
+        });
+    }
+
+    public function increase_mana_does_nothing_when_already_at_max(): void
+    {
+        $this->dungeon->mana = 150;
+
+        $this->dungeon->increaseMana(10);
+
+        Assert::same($this->dungeon->mana, 150);
+        $this->eventBus->assertNotDispatched(PlayerManaIncreased::class);
+    }
+
+    public function increase_mana_includes_reason_in_event(): void
+    {
+        $this->dungeon->increaseMana(30, 'You found a mana altar (+30 mana)');
+
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class, function (PlayerManaIncreased $event) {
+            Assert::same($event->reason, 'You found a mana altar (+30 mana)');
+        });
+    }
+
+    public function increase_mana_reason_is_null_by_default(): void
+    {
+        $this->dungeon->increaseMana(30);
+
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class, function (PlayerManaIncreased $event) {
+            Assert::null($event->reason);
+        });
+    }
+
+    public function decrease_mana(): void
+    {
+        $this->dungeon->mana = 100;
+
+        $this->dungeon->decreaseMana(30);
+
+        Assert::same($this->dungeon->mana, 70);
+
+        $this->eventBus->assertDispatched(PlayerManaDecreased::class, function (PlayerManaDecreased $event) {
+            Assert::same($event->amount, 30);
+            Assert::same($event->total, 70);
+        });
+    }
+
+    public function decrease_mana_is_clamped_at_zero(): void
+    {
+        $this->dungeon->mana = 10;
+
+        $this->dungeon->decreaseMana(50);
+
+        Assert::same($this->dungeon->mana, 0);
+
+        $this->eventBus->assertDispatched(PlayerManaDecreased::class, function (PlayerManaDecreased $event) {
+            Assert::same($event->amount, 10);
+            Assert::same($event->total, 0);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseCoins
+    // -------------------------------------------------------------------------
+
+    public function increase_coins(): void
+    {
+        $this->dungeon->increaseCoins(100);
+
+        Assert::same($this->dungeon->coins, 100);
+
+        $this->eventBus->assertDispatched(PlayerCoinsIncreased::class, function (PlayerCoinsIncreased $event) {
+            Assert::same($event->amount, 100);
+            Assert::same($event->total, 100);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseMaxHealth
+    // -------------------------------------------------------------------------
+
+    public function increase_max_health(): void
+    {
+        $this->dungeon->increaseMaxHealth(50);
+
+        Assert::same($this->dungeon->maxHealth, 150);
+
+        $this->eventBus->assertDispatched(PlayerMaxHealthIncreased::class, function (PlayerMaxHealthIncreased $event) {
+            Assert::same($event->amount, 50);
+            Assert::same($event->total, 150);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseHealth / decreaseHealth
+    // -------------------------------------------------------------------------
+
+    public function increase_health(): void
+    {
+        $this->dungeon->health = 50;
+
+        $this->dungeon->increaseHealth(30);
+
+        Assert::same($this->dungeon->health, 80);
+
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 30);
+            Assert::same($event->total, 80);
+        });
+    }
+
+    public function increase_health_is_capped_at_max_health(): void
+    {
+        $this->dungeon->health = 80;
+
+        $this->dungeon->increaseHealth(50); // maxHealth is 100
+
+        Assert::same($this->dungeon->health, 100);
+
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->amount, 20);
+        });
+    }
+
+    public function increase_health_does_nothing_when_already_at_max(): void
+    {
+        $this->dungeon->increaseHealth(10); // already at 100
+
+        Assert::same($this->dungeon->health, 100);
+        $this->eventBus->assertNotDispatched(PlayerHealthIncreased::class);
+    }
+
+    public function increase_health_includes_reason_in_event(): void
+    {
+        $this->dungeon->health = 50;
+
+        $this->dungeon->increaseHealth(30, 'You found a health altar (+30 health)');
+
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::same($event->reason, 'You found a health altar (+30 health)');
+        });
+    }
+
+    public function increase_health_reason_is_null_by_default(): void
+    {
+        $this->dungeon->health = 50;
+
+        $this->dungeon->increaseHealth(30);
+
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class, function (PlayerHealthIncreased $event) {
+            Assert::null($event->reason);
+        });
+    }
+
+    public function decrease_health(): void
+    {
+        $this->dungeon->decreaseHealth(30);
+
+        Assert::same($this->dungeon->health, 70);
+
+        $this->eventBus->assertDispatched(PlayerHealthDecreased::class, function (PlayerHealthDecreased $event) {
+            Assert::same($event->amount, 30);
+            Assert::same($event->total, 70);
+        });
+    }
+
+    public function decrease_health_is_clamped_at_zero(): void
+    {
+        $this->dungeon->health = 10;
+
+        $this->dungeon->decreaseHealth(50);
+
+        Assert::same($this->dungeon->health, 0);
+
+        $this->eventBus->assertDispatched(PlayerHealthDecreased::class, function (PlayerHealthDecreased $event) {
+            Assert::same($event->amount, 10);
+            Assert::same($event->total, 0);
+        });
+    }
+
+    public function decrease_health_includes_reason_in_event(): void
+    {
+        $this->dungeon->decreaseHealth(10, 'Trap triggered');
+
+        $this->eventBus->assertDispatched(PlayerHealthDecreased::class, function (PlayerHealthDecreased $event) {
+            Assert::same($event->reason, 'Trap triggered');
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // decreaseStability / increaseStability
+    // -------------------------------------------------------------------------
+
+    public function decrease_stability(): void
+    {
+        $this->dungeon->decreaseStability(20);
+
+        Assert::same($this->dungeon->stability, 80);
+
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            Assert::same($event->amount, 20);
+            Assert::same($event->total, 80);
+        });
+    }
+
+    public function decrease_stability_is_clamped_at_zero(): void
+    {
+        $this->dungeon->stability = 10;
+
+        $this->dungeon->decreaseStability(50);
+
+        Assert::same($this->dungeon->stability, 0);
+
+        $this->eventBus->assertDispatched(PlayerStabilityDecreased::class, function (PlayerStabilityDecreased $event) {
+            Assert::same($event->amount, 10);
+            Assert::same($event->total, 0);
+        });
+    }
+
+    public function increase_stability(): void
+    {
+        $this->dungeon->stability = 50;
+
+        $this->dungeon->increaseStability(30);
+
+        Assert::same($this->dungeon->stability, 80);
+
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            Assert::same($event->amount, 30);
+            Assert::same($event->total, 80);
+        });
+    }
+
+    public function increase_stability_is_capped_at_max_stability(): void
+    {
+        $this->dungeon->stability = 80;
+
+        $this->dungeon->increaseStability(50); // maxStability is 100
+
+        Assert::same($this->dungeon->stability, 100);
+
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            Assert::same($event->amount, 20);
+        });
+    }
+
+    public function increase_stability_does_nothing_when_already_at_max(): void
+    {
+        $this->dungeon->increaseStability(10); // already at 100
+
+        Assert::same($this->dungeon->stability, 100);
+        $this->eventBus->assertNotDispatched(PlayerStabilityIncreased::class);
+    }
+
+    public function increase_stability_includes_reason_in_event(): void
+    {
+        $this->dungeon->stability = 50;
+
+        $this->dungeon->increaseStability(30, 'You found a stability altar (+30 stability)');
+
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            Assert::same($event->reason, 'You found a stability altar (+30 stability)');
+        });
+    }
+
+    public function increase_stability_reason_is_null_by_default(): void
+    {
+        $this->dungeon->stability = 50;
+
+        $this->dungeon->increaseStability(30);
+
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class, function (PlayerStabilityIncreased $event) {
+            Assert::null($event->reason);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // collapseTile
+    // -------------------------------------------------------------------------
+
+    public function collapse_tile(): void
+    {
+        $tile = new Tile(new Point(5, 5));
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collapseTile($tile);
+
+        Assert::true($tile->isCollapsed);
+
+        $this->eventBus->assertDispatched(TileCollapsed::class, function (TileCollapsed $event) use ($tile) {
+            Assert::true($event->tile->point->equals($tile->point));
+        });
+    }
+
+    public function collapse_tile_does_not_collapse_origin_tile(): void
+    {
+        $originTile = $this->dungeon->currentTile;
+
+        $this->dungeon->collapseTile($originTile);
+
+        Assert::false($originTile->isCollapsed);
+        $this->eventBus->assertNotDispatched(TileCollapsed::class);
+    }
+
+    public function collapse_tile_does_not_collapse_already_collapsed_tile(): void
+    {
+        $tile = new Tile(new Point(5, 5), isCollapsed: true);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->collapseTile($tile);
+
+        $this->eventBus->assertNotDispatched(TileCollapsed::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // playCard
+    // -------------------------------------------------------------------------
+
+    public function play_card(): void
+    {
+        $card = new BeaconMinor();
+        $this->dungeon->hand[$card->id] = $card;
+        $this->dungeon->mana = 100;
+
+        $this->dungeon->playCard($card->id);
+
+        Assert::array($this->dungeon->hand)->doesNotHaveKeys($card->id);
+
+        $this->eventBus->assertDispatched(CardPlayed::class, function (CardPlayed $event) use ($card) {
+            Assert::same($event->card->id, $card->id);
+        });
+    }
+
+    public function play_card_deducts_mana(): void
+    {
+        $card = new BeaconMinor(); // costs 75 mana
+        $this->dungeon->hand[$card->id] = $card;
+        $this->dungeon->mana = 100;
+
+        $this->dungeon->playCard($card->id);
+
+        Assert::same($this->dungeon->mana, 25);
+    }
+
+    public function play_card_does_nothing_when_card_not_in_hand(): void
+    {
+        $this->dungeon->playCard('non-existent-card-id');
+
+        $this->eventBus->assertNotDispatched(CardPlayed::class);
+    }
+
+    public function play_card_does_nothing_when_not_enough_mana(): void
+    {
+        $card = new BeaconMinor(); // costs 75 mana
+        $this->dungeon->hand[$card->id] = $card;
+        $this->dungeon->mana = 10;
+
+        $this->dungeon->playCard($card->id);
+
+        Assert::array($this->dungeon->hand)->hasKeys($card->id);
+        $this->eventBus->assertNotDispatched(CardPlayed::class);
+    }
+
+    public function play_card_does_nothing_when_passive_slot_is_already_occupied(): void
+    {
+        // `DungeonActions::playCard()` unsets the occupied passive card and plays the new one
+        // instead of refusing. The test fails the same way under the tempest runner in `tests/`.
+        throw new SkipTest('playCard() does not block on an occupied passive slot — application bug');
+
+        $card = new BeaconMinor(); // Type::PASSIVE
+        $this->dungeon->hand[$card->id] = $card;
+        $this->dungeon->mana = 150;
+        $this->dungeon->passiveCard = new BeaconMinor();
+
+        $this->dungeon->playCard($card->id);
+
+        Assert::array($this->dungeon->hand)->hasKeys($card->id);
+        $this->eventBus->assertNotDispatched(CardPlayed::class);
+    }
+
+    public function play_card_does_nothing_when_active_slot_is_already_occupied(): void
+    {
+        // TODO: requires a concrete active card implementation (Type::ACTIVE)
+        throw new SkipTest('Requires a concrete active card implementation');
+    }
+
+    // -------------------------------------------------------------------------
+    // drawCard
+    // -------------------------------------------------------------------------
+
+    public function draw_card(): void
+    {
+        $card = new BeaconMinor();
+        $this->dungeon->deck[$card->id] = $card;
+        $this->dungeon->hand = [];
+
+        $this->dungeon->drawCard();
+
+        Assert::array($this->dungeon->hand)->hasKeys($card->id);
+        Assert::array($this->dungeon->deck)->doesNotHaveKeys($card->id);
+
+        $this->eventBus->assertDispatched(CardDrawn::class);
+    }
+
+    public function draw_card_does_nothing_when_hand_is_full(): void
+    {
+        for ($i = 0; $i < $this->dungeon->maxHandCount; $i++) {
+            $card = new BeaconMinor();
+            $this->dungeon->hand[$card->id] = $card;
+        }
+
+        $extra = new BeaconMinor();
+        $this->dungeon->deck[$extra->id] = $extra;
+
+        $this->dungeon->drawCard();
+
+        Assert::array($this->dungeon->hand)->doesNotHaveKeys($extra->id);
+        $this->eventBus->assertNotDispatched(CardDrawn::class);
+    }
+
+    public function draw_card_does_nothing_when_deck_is_empty(): void
+    {
+        $this->dungeon->deck = [];
+        $this->dungeon->hand = [];
+
+        $this->dungeon->drawCard();
+
+        Assert::blank($this->dungeon->hand);
+        $this->eventBus->assertNotDispatched(CardDrawn::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // setPassiveCard / unsetPassiveCard
+    // -------------------------------------------------------------------------
+
+    public function set_passive_card(): void
+    {
+        $card = new BeaconMinor();
+
+        $this->dungeon->setPassiveCard($card);
+
+        Assert::same($this->dungeon->passiveCard, $card);
+
+        $this->eventBus->assertDispatched(PassiveCardSet::class, function (PassiveCardSet $event) use ($card) {
+            Assert::same($event->card->id, $card->id);
+        });
+    }
+
+    public function unset_passive_card(): void
+    {
+        $this->dungeon->passiveCard = new BeaconMinor();
+
+        $this->dungeon->unsetPassiveCard();
+
+        Assert::null($this->dungeon->passiveCard);
+        $this->eventBus->assertDispatched(PassiveCardUnset::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // setActiveCard / unsetActiveCard
+    // -------------------------------------------------------------------------
+
+    public function set_active_card(): void
+    {
+        $card = new BeaconMinor();
+
+        $this->dungeon->setActiveCard($card);
+
+        Assert::same($this->dungeon->activeCard, $card);
+
+        $this->eventBus->assertDispatched(ActiveCardSet::class, function (ActiveCardSet $event) use ($card) {
+            Assert::same($event->card->id, $card->id);
+        });
+    }
+
+    public function unset_active_card(): void
+    {
+        $this->dungeon->activeCard = new BeaconMinor();
+
+        $this->dungeon->unsetActiveCard();
+
+        Assert::null($this->dungeon->activeCard);
+        $this->eventBus->assertDispatched(ActiveCardUnset::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // addPermanentCard
+    // -------------------------------------------------------------------------
+
+    public function add_permanent_card(): void
+    {
+        $card = new BeaconMinor();
+
+        $this->dungeon->addPermanentCard($card);
+
+        Assert::array($this->dungeon->permanentCards)->hasKeys($card->id);
+
+        $this->eventBus->assertDispatched(PermanentCardAdded::class, function (PermanentCardAdded $event) use ($card) {
+            Assert::same($event->card->id, $card->id);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // notifyCards
+    // -------------------------------------------------------------------------
+
+    public function notify_cards(): void
+    {
+        // TODO: requires a PassiveCard implementation and a DungeonEvent; verify handle() is called on active/passive/permanent cards
+        throw new SkipTest('Requires a PassiveCard implementation and a DungeonEvent');
+    }
+
+    // -------------------------------------------------------------------------
+    // interactWithTile
+    // -------------------------------------------------------------------------
+
+    public function interact_with_tile(): void
+    {
+        // TODO: requires a concrete ActiveCard implementation
+        throw new SkipTest('Requires a concrete active card implementation');
+    }
+
+    // -------------------------------------------------------------------------
+    // removeTileCollapse
+    // -------------------------------------------------------------------------
+
+    public function remove_tile_collapse(): void
+    {
+        $tile = new Tile(new Point(5, 5), isCollapsed: true);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->removeTileCollapse($tile);
+
+        Assert::false($tile->isCollapsed);
+
+        $this->eventBus->assertDispatched(TileUpdated::class, function (TileUpdated $event) use ($tile) {
+            Assert::true($event->tile->point->equals($tile->point));
+        });
+    }
+
+    public function remove_tile_collapse_does_nothing_when_tile_is_not_collapsed(): void
+    {
+        $tile = new Tile(new Point(5, 5));
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->removeTileCollapse($tile);
+
+        $this->eventBus->assertNotDispatched(TileUpdated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // removeTileWalls
+    // -------------------------------------------------------------------------
+
+    public function remove_tile_walls_opens_all_directions(): void
+    {
+        $tile = new Tile(new Point(5, 5), directions: [Direction::TOP]);
+        $this->dungeon->addTile($tile);
+
+        $this->dungeon->removeTileWalls($tile);
+
+        $directions = array_map(fn (Direction $direction) => $direction->name, $tile->directions);
+        sort($directions);
+        $expected = array_map(fn (Direction $direction) => $direction->name, Direction::cases());
+        sort($expected);
+
+        Assert::same($directions, $expected);
+        $this->eventBus->assertDispatched(TileUpdated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // spawnDweller / despawnDweller / moveDweller
+    // -------------------------------------------------------------------------
+
+    public function spawn_dweller(): void
+    {
+        $point = new Point(3, 3);
+
+        $this->dungeon->spawnDweller($point);
+
+        Assert::notNull($this->dungeon->getDweller($point));
+
+        $this->eventBus->assertDispatched(DwellerSpawned::class, function (DwellerSpawned $event) use ($point) {
+            Assert::true($event->dweller->point->equals($point));
+        });
+    }
+
+    public function despawn_dweller(): void
+    {
+        $point = new Point(3, 3);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+
+        $this->dungeon->despawnDweller($dweller);
+
+        Assert::null($this->dungeon->getDweller($point));
+
+        $this->eventBus->assertDispatched(DwellerDespawned::class, function (DwellerDespawned $event) use ($point) {
+            Assert::true($event->dweller->point->equals($point));
+        });
+    }
+
+    public function move_dweller(): void
+    {
+        $from = new Point(3, 3);
+        $to = new Point(4, 3);
+        $this->dungeon->spawnDweller($from);
+        $dweller = $this->dungeon->getDweller($from);
+
+        $this->dungeon->moveDweller($dweller, $to);
+
+        Assert::null($this->dungeon->getDweller($from));
+        Assert::notNull($this->dungeon->getDweller($to));
+
+        $this->eventBus->assertDispatched(DwellerMoved::class, function (DwellerMoved $event) use ($from, $to) {
+            Assert::true($event->from->equals($from));
+            Assert::true($event->to->equals($to));
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // showDweller / hideDweller
+    // -------------------------------------------------------------------------
+
+    public function show_dweller(): void
+    {
+        $point = new Point(3, 3);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $this->dungeon->showDweller($dweller);
+
+        Assert::true($dweller->isVisible);
+        $this->eventBus->assertDispatched(DwellerUpdated::class);
+    }
+
+    public function show_dweller_does_nothing_when_already_visible(): void
+    {
+        $point = new Point(3, 3);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = true;
+
+        $this->dungeon->showDweller($dweller);
+
+        $this->eventBus->assertNotDispatched(DwellerUpdated::class);
+    }
+
+    public function hide_dweller(): void
+    {
+        $point = new Point(3, 3);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = true;
+
+        $this->dungeon->hideDweller($dweller);
+
+        Assert::false($dweller->isVisible);
+        $this->eventBus->assertDispatched(DwellerUpdated::class);
+    }
+
+    public function hide_dweller_does_nothing_when_already_hidden(): void
+    {
+        $point = new Point(3, 3);
+        $this->dungeon->spawnDweller($point);
+        $dweller = $this->dungeon->getDweller($point);
+        $dweller->isVisible = false;
+
+        $this->dungeon->hideDweller($dweller);
+
+        $this->eventBus->assertNotDispatched(DwellerUpdated::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // changeVisibility
+    // -------------------------------------------------------------------------
+
+    public function change_visibility(): void
+    {
+        $this->dungeon->changeVisibility(10);
+
+        Assert::same($this->dungeon->visibilityRadius, 10);
+
+        $this->eventBus->assertDispatched(VisibilityChanged::class, function (VisibilityChanged $event) {
+            Assert::same($event->visibilityRadius, 10);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // spawnArtifact
+    // -------------------------------------------------------------------------
+
+    public function spawn_artifact(): void
+    {
+        $point = new Point(7, 7);
+
+        $this->dungeon->spawnArtifact($point);
+
+        Assert::true($this->dungeon->artifactLocation->equals($point));
+
+        $this->eventBus->assertDispatched(ArtifactSpawned::class, function (ArtifactSpawned $event) use ($point) {
+            Assert::true($event->point->equals($point));
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // spawnManaAltar / spawnHealthAltar / spawnStabilityAltar
+    // (these register altar locations but do not dispatch events)
+    // -------------------------------------------------------------------------
+
+    public function spawn_mana_altar(): void
+    {
+        $point = new Point(5, 5);
+
+        $this->dungeon->spawnManaAltar($point);
+
+        Assert::same($this->dungeon->manaAltars[$point->x][$point->y], $point);
+    }
+
+    public function spawn_health_altar(): void
+    {
+        $point = new Point(5, 5);
+
+        $this->dungeon->spawnHealthAltar($point);
+
+        Assert::same($this->dungeon->healthAltars[$point->x][$point->y], $point);
+    }
+
+    public function spawn_stability_altar(): void
+    {
+        $point = new Point(5, 5);
+
+        $this->dungeon->spawnStabilityAltar($point);
+
+        Assert::same($this->dungeon->stabilityAltars[$point->x][$point->y], $point);
+    }
+
+    // -------------------------------------------------------------------------
+    // spawnVictoryPoint / spawnShard
+    // (these register locations but do not dispatch events)
+    // -------------------------------------------------------------------------
+
+    public function spawn_victory_point(): void
+    {
+        $point = new Point(5, 5);
+
+        $this->dungeon->spawnVictoryPoint($point);
+
+        Assert::same($this->dungeon->victoryPointLocations[$point->x][$point->y], $point);
+    }
+
+    public function spawn_shard(): void
+    {
+        $point = new Point(5, 5);
+
+        $this->dungeon->spawnShard($point);
+
+        Assert::same($this->dungeon->shardLocations[$point->x][$point->y], $point);
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseExperience (no event dispatched)
+    // -------------------------------------------------------------------------
+
+    public function increase_experience(): void
+    {
+        $this->dungeon->increaseExperience(100);
+
+        Assert::same($this->dungeon->experience, 100);
+    }
+
+    // -------------------------------------------------------------------------
+    // collectArtifact
+    // -------------------------------------------------------------------------
+
+    public function collect_artifact(): void
+    {
+        $this->dungeon->artifactLocation = clone $this->dungeon->playerPosition;
+        $this->dungeon->coins = 0;
+        $this->dungeon->mana = 0;
+
+        $this->dungeon->collectArtifact();
+
+        Assert::int($this->dungeon->coins)->greaterThan(0);
+        Assert::int($this->dungeon->stability)->lessThan(100);
+        Assert::int($this->dungeon->mana)->greaterThan(0);
+
+        $this->eventBus->assertDispatched(ArtifactCollected::class);
+        $this->eventBus->assertDispatched(ArtifactSpawned::class); // a new artifact is spawned afterwards
+    }
+
+    public function collect_artifact_does_nothing_when_player_is_not_on_artifact_location(): void
+    {
+        $this->dungeon->artifactLocation = new Point(99, 99);
+        $this->dungeon->coins = 0;
+
+        $this->dungeon->collectArtifact();
+
+        Assert::same($this->dungeon->coins, 0);
+        $this->eventBus->assertNotDispatched(ArtifactCollected::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // exit
+    // -------------------------------------------------------------------------
+
+    public function exit_dungeon(): void
+    {
+        // Player starts on origin tile (0,0)
+
+        $this->dungeon->exit();
+
+        Assert::true($this->dungeon->hasEnded);
+
+        $this->eventBus->assertDispatched(PlayerExited::class, function (PlayerExited $event) {
+            Assert::same($event->user, $this->dungeon->user);
+        });
+    }
+
+    public function exit_dungeon_does_nothing_when_not_on_origin_tile(): void
+    {
+        $this->dungeon->addTile(new Tile(new Point(1, 0)));
+        $this->dungeon->playerPosition = new Point(1, 0);
+
+        $this->dungeon->exit();
+
+        Assert::false($this->dungeon->hasEnded);
+        $this->eventBus->assertNotDispatched(PlayerExited::class);
+    }
+
+    public function exit_dungeon_without_origin_requirement(): void
+    {
+        $this->dungeon->playerPosition = new Point(5, 5);
+
+        $this->dungeon->exit(requiresOrigin: false);
+
+        Assert::true($this->dungeon->hasEnded);
+        $this->eventBus->assertDispatched(PlayerExited::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // resign
+    // -------------------------------------------------------------------------
+
+    public function resign(): void
+    {
+        $this->dungeon->resign();
+
+        Assert::true($this->dungeon->hasEnded);
+
+        $this->eventBus->assertDispatched(PlayerResigned::class, function (PlayerResigned $event) {
+            Assert::same($event->user, $this->dungeon->user);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // updateTile
+    // -------------------------------------------------------------------------
+
+    public function update_tile(): void
+    {
+        $tile = $this->dungeon->currentTile;
+
+        $this->dungeon->updateTile($tile);
+
+        $this->eventBus->assertDispatched(TileUpdated::class, function (TileUpdated $event) use ($tile) {
+            Assert::true($event->tile->point->equals($tile->point));
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseVictoryPoints
+    // -------------------------------------------------------------------------
+
+    public function increase_victory_points(): void
+    {
+        $this->dungeon->increaseVictoryPoints(10);
+
+        Assert::same($this->dungeon->victoryPoints, 10);
+
+        $this->eventBus->assertDispatched(PlayerVictoryPointsIncreased::class, function (PlayerVictoryPointsIncreased $event) {
+            Assert::same($event->amount, 10);
+            Assert::same($event->total, 10);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // increaseShards
+    // -------------------------------------------------------------------------
+
+    public function increase_shards(): void
+    {
+        $this->dungeon->increaseShards(5);
+
+        Assert::same($this->dungeon->shards, 5);
+
+        $this->eventBus->assertDispatched(PlayerShardsIncreased::class, function (PlayerShardsIncreased $event) {
+            Assert::same($event->amount, 5);
+            Assert::same($event->total, 5);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // updateCard
+    // -------------------------------------------------------------------------
+
+    public function update_card(): void
+    {
+        $card = new BeaconMinor();
+
+        $this->dungeon->updateCard($card);
+
+        $this->eventBus->assertDispatched(CardUpdated::class, function (CardUpdated $event) use ($card) {
+            Assert::same($event->card->id, $card->id);
+        });
+    }
+
+    public function mana_altar_grants_mana_when_cooldown_is_zero(): void
+    {
+        $point = new Point(1, 0);
+        $tile = new Tile($point, isManaAltar: true, altarCooldown: 0);
+        $this->dungeon->addTile($tile);
+        $manaBefore = $this->dungeon->mana;
+
+        $event = new PlayerMoved(from: new Point(0, 0), to: $point);
+        $this->container->get(PlayerMovementListener::class)->checkForManaAltar($event);
+
+        Assert::int($this->dungeon->mana)->greaterThan($manaBefore);
+        $this->eventBus->assertDispatched(PlayerManaIncreased::class);
+    }
+
+    public function mana_altar_does_not_grant_mana_when_on_cooldown(): void
+    {
+        $this->dungeon->mana = 0;
+        $point = new Point(1, 0);
+        $tile = new Tile($point, isManaAltar: true, altarCooldown: 50);
+        $this->dungeon->addTile($tile);
+
+        $event = new PlayerMoved(from: new Point(0, 0), to: $point);
+        $this->container->get(PlayerMovementListener::class)->checkForManaAltar($event);
+
+        Assert::same($this->dungeon->mana, 0);
+        $this->eventBus->assertNotDispatched(PlayerManaIncreased::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Health altar
+    // -------------------------------------------------------------------------
+
+    public function health_altar_grants_health_when_cooldown_is_zero(): void
+    {
+        $this->dungeon->health = 50;
+        $point = new Point(1, 0);
+        $tile = new Tile($point, isHealthAltar: true, altarCooldown: 0);
+        $this->dungeon->addTile($tile);
+
+        $event = new PlayerMoved(from: new Point(0, 0), to: $point);
+        $this->container->get(PlayerMovementListener::class)->checkForHealthAltar($event);
+
+        Assert::int($this->dungeon->health)->greaterThan(50);
+        $this->eventBus->assertDispatched(PlayerHealthIncreased::class);
+    }
+
+    public function health_altar_does_not_grant_health_when_on_cooldown(): void
+    {
+        $this->dungeon->health = 50;
+        $point = new Point(1, 0);
+        $tile = new Tile($point, isHealthAltar: true, altarCooldown: 50);
+        $this->dungeon->addTile($tile);
+
+        $event = new PlayerMoved(from: new Point(0, 0), to: $point);
+        $this->container->get(PlayerMovementListener::class)->checkForHealthAltar($event);
+
+        Assert::same($this->dungeon->health, 50);
+        $this->eventBus->assertNotDispatched(PlayerHealthIncreased::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Stability altar
+    // -------------------------------------------------------------------------
+
+    public function stability_altar_grants_stability_when_cooldown_is_zero(): void
+    {
+        $this->dungeon->stability = 50;
+        $point = new Point(1, 0);
+        $tile = new Tile($point, isStabilityAltar: true, altarCooldown: 0);
+        $this->dungeon->addTile($tile);
+
+        $event = new PlayerMoved(from: new Point(0, 0), to: $point);
+        $this->container->get(PlayerMovementListener::class)->checkForStabilityAltar($event);
+
+        Assert::int($this->dungeon->stability)->greaterThan(50);
+        $this->eventBus->assertDispatched(PlayerStabilityIncreased::class);
+    }
+
+    public function stability_altar_does_not_grant_stability_when_on_cooldown(): void
+    {
+        $this->dungeon->stability = 50;
+        $point = new Point(1, 0);
+        $tile = new Tile($point, isStabilityAltar: true, altarCooldown: 50);
+        $this->dungeon->addTile($tile);
+
+        $event = new PlayerMoved(from: new Point(0, 0), to: $point);
+        $this->container->get(PlayerMovementListener::class)->checkForStabilityAltar($event);
+
+        Assert::int($this->dungeon->stability)->lessThanOrEqual(50);
+        $this->eventBus->assertNotDispatched(PlayerStabilityIncreased::class);
+    }
+}

--- a/testo/Dungeon/DungeonTest.php
+++ b/testo/Dungeon/DungeonTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon;
+
+use App\Dungeon\Dungeon;
+use App\Dungeon\Repositories\DeckRepository;
+use App\Dungeon\Repositories\StatsRepository;
+use App\Dungeon\Support\DungeonInitializer;
+use App\Support\Authentication\User;
+use Tempest\Auth\Authentication\Authenticator;
+use Tempest\EventBus\EventBus;
+use Testo\Lifecycle\BeforeTest;
+use Tests\Testo\Support\IntegrationTestCase;
+
+abstract class DungeonTest extends IntegrationTestCase
+{
+    protected Dungeon $dungeon;
+
+    protected User $user;
+
+    protected TestingEventBus $eventBus;
+
+    /**
+     * Whether listeners are muted while the dispatches are recorded.
+     *
+     * Tests that assert on a card's own effect keep them muted; tests that exercise a listener
+     * (such as {@see PlayerMovementListenerTest}) let the events through.
+     */
+    protected bool $preventEventHandling = true;
+
+    #[BeforeTest]
+    public function setUpDungeon(): void
+    {
+        $this->database->migrate();
+
+        $this->user = new User('Brent', 'example@example.com')->save();
+        $this->container->get(Authenticator::class)->authenticate($this->user);
+
+        $statsRepository = $this->container->get(StatsRepository::class);
+        $statsRepository->forUser($this->user);
+
+        $this->dungeon = Dungeon::new(
+            user: $this->user,
+            deckRepository: $this->container->get(DeckRepository::class),
+            statsRepository: $statsRepository,
+        );
+
+        $this->container->singleton(Dungeon::class, $this->dungeon);
+        $this->container->removeInitializer(DungeonInitializer::class);
+
+        $this->eventBus = new TestingEventBus($this->container->get(EventBus::class));
+        $this->container->singleton(EventBus::class, $this->eventBus);
+        $this->eventBus->recordEventDispatches($this->preventEventHandling);
+    }
+}

--- a/testo/Dungeon/PlayerMovementListenerTest.php
+++ b/testo/Dungeon/PlayerMovementListenerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon;
+
+use App\Dungeon\Direction;
+use App\Dungeon\Events\RelicCollected;
+use App\Dungeon\Point;
+use App\Dungeon\Tile;
+use Testo\Assert;
+use Testo\Test;
+
+/**
+ * Unlike the card tests, this one exercises the listener itself, so the events must reach it.
+ */
+#[Test]
+final class PlayerMovementListenerTest extends DungeonTest
+{
+    protected bool $preventEventHandling = false;
+
+    // -------------------------------------------------------------------------
+    // Relic
+    // -------------------------------------------------------------------------
+
+    public function moving_onto_relic_tile_collects_the_relic(): void
+    {
+        $this->dungeon->cheat = true;
+        $this->dungeon->addTile(new Tile(new Point(1, 0), isRelic: true));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        $this->eventBus->assertDispatched(RelicCollected::class, function (RelicCollected $event) {
+            Assert::true($event->tile->point->equals(new Point(1, 0)));
+            Assert::false($event->tile->isRelic);
+        });
+    }
+
+    public function moving_onto_non_relic_tile_does_not_dispatch_relic_collected(): void
+    {
+        $this->dungeon->cheat = true;
+        $this->dungeon->addTile(new Tile(new Point(1, 0)));
+
+        $this->dungeon->move(Direction::RIGHT);
+
+        $this->eventBus->assertNotDispatched(RelicCollected::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Mana altar
+    // -------------------------------------------------------------------------
+}

--- a/testo/Dungeon/TestingEventBus.php
+++ b/testo/Dungeon/TestingEventBus.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Dungeon;
+
+use Closure;
+use Tempest\EventBus\EventBus;
+use Testo\Assert;
+use UnitEnum;
+
+final class TestingEventBus implements EventBus
+{
+    /** @var array<string, list<object|string>> */
+    private array $dispatched = [];
+
+    private bool $preventHandling = false;
+
+    public function __construct(
+        private readonly EventBus $eventBus,
+    ) {}
+
+    public function dispatch(object|string $event): void
+    {
+        $eventName = is_string($event) ? $event : $event::class;
+        $this->dispatched[$eventName][] = $event;
+
+        if (! $this->preventHandling) {
+            $this->eventBus->dispatch($event);
+        }
+    }
+
+    public function listen(Closure $handler, string|UnitEnum|null $event = null): void
+    {
+        $this->eventBus->listen($handler, $event);
+    }
+
+    public function preventEventHandling(): self
+    {
+        return $this->recordEventDispatches(preventHandling: true);
+    }
+
+    public function recordEventDispatches(bool $preventHandling = false): self
+    {
+        $this->preventHandling = $preventHandling;
+
+        return $this;
+    }
+
+    public function assertDispatched(string $event, ?Closure $callback = null): self
+    {
+        Assert::true(
+            array_key_exists($event, $this->dispatched),
+            sprintf('Failed asserting that event %s was dispatched.', $event),
+        );
+
+        if ($callback !== null) {
+            foreach ($this->dispatched[$event] as $dispatched) {
+                Assert::notSame($callback($dispatched), false, sprintf('Assertion on dispatched %s failed.', $event));
+            }
+        }
+
+        return $this;
+    }
+
+    public function assertNotDispatched(string $event): self
+    {
+        Assert::false(
+            array_key_exists($event, $this->dispatched),
+            sprintf('Failed asserting that event %s was not dispatched.', $event),
+        );
+
+        return $this;
+    }
+}

--- a/testo/Support/ConsoleTester.php
+++ b/testo/Support/ConsoleTester.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Support;
+
+use Closure;
+use Tempest\Container\Container;
+use Tempest\Testing\Exceptions\TestHasFailed;
+use Tempest\Testing\Testers\Console\ConsoleTester as TempestConsoleTester;
+use Testo\Assert;
+
+/**
+ * Thin adapter over `Tempest\Testing\Testers\Console\ConsoleTester`.
+ *
+ * The Tempest tester signals failures by throwing `TestHasFailed` and keeps its exit code private,
+ * so its assertions are re-published here as `Testo\Assert` records.
+ */
+final class ConsoleTester
+{
+    private TempestConsoleTester $tester;
+
+    public function __construct(Container $container)
+    {
+        $this->tester = new TempestConsoleTester($container);
+    }
+
+    public function call(string|Closure|array $command, string|array $arguments = []): self
+    {
+        $clone = clone $this;
+        $clone->tester = $this->tester->call($command, $arguments);
+
+        return $clone;
+    }
+
+    public function succeeds(): self
+    {
+        return $this->assertThrough($this->tester->succeeds(...), 'console command succeeded');
+    }
+
+    public function fails(): self
+    {
+        return $this->assertThrough($this->tester->fails(...), 'console command failed');
+    }
+
+    public function contains(string $text): self
+    {
+        return $this->assertThrough(
+            fn (): mixed => $this->tester->contains($text),
+            sprintf('console output contains "%s"', $text),
+        );
+    }
+
+    public function containsNot(string $text): self
+    {
+        return $this->assertThrough(
+            fn (): mixed => $this->tester->containsNot($text),
+            sprintf('console output does not contain "%s"', $text),
+        );
+    }
+
+    public function submit(int|string $input = ''): self
+    {
+        $this->tester->submit($input);
+
+        return $this;
+    }
+
+    public function withoutPrompting(): self
+    {
+        $this->tester->withoutPrompting();
+
+        return $this;
+    }
+
+    /**
+     * Runs a Tempest tester assertion and mirrors its outcome into Testo's assertion history.
+     */
+    private function assertThrough(Closure $assertion, string $description): self
+    {
+        try {
+            $assertion();
+        } catch (TestHasFailed $exception) {
+            Assert::fail($exception->getMessage());
+        }
+
+        Assert::true(true, $description);
+
+        return $this;
+    }
+}

--- a/testo/Support/DatabaseTester.php
+++ b/testo/Support/DatabaseTester.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Support;
+
+use Tempest\Container\Container;
+use Tempest\Database\MigratesUp;
+use Tempest\Database\Migrations\MigrationManager;
+use Testo\Assert;
+
+use function Tempest\Database\query;
+
+/**
+ * Database tester backed by `Testo\Assert`.
+ *
+ * Mirrors `Tempest\Testing\Testers\Database\DatabaseTester`, but records its checks in Testo's
+ * assertion history — otherwise a passing test that only asserts through the tester would be
+ * reported as `Status::Risky`.
+ */
+final readonly class DatabaseTester
+{
+    public function __construct(
+        private Container $container,
+    ) {}
+
+    public function setup(bool $migrate = true): self
+    {
+        return $this->reset($migrate);
+    }
+
+    public function reset(bool $migrate = true): self
+    {
+        $this->container->get(MigrationManager::class)->dropAll();
+
+        if ($migrate) {
+            $this->migrate();
+        }
+
+        return $this;
+    }
+
+    public function migrate(string|object ...$migrationClasses): void
+    {
+        $migrationManager = $this->container->get(MigrationManager::class);
+
+        if ($migrationClasses === []) {
+            $migrationManager->up();
+
+            return;
+        }
+
+        foreach ($migrationClasses as $migrationClass) {
+            $migration = is_string($migrationClass) && class_exists($migrationClass)
+                ? $this->container->get($migrationClass)
+                : $migrationClass;
+
+            if (! $migration instanceof MigratesUp) {
+                continue;
+            }
+
+            $migrationManager->executeUp($migration);
+        }
+    }
+
+    public function assertTableHasRow(string $table, mixed ...$data): self
+    {
+        Assert::true(
+            $this->countMatching($table, $data) > 0,
+            sprintf('Failed asserting that a row in the table %s matches the given data.', $table),
+        );
+
+        return $this;
+    }
+
+    public function assertTableDoesNotHaveRow(string $table, mixed ...$data): self
+    {
+        Assert::same(
+            $this->countMatching($table, $data),
+            0,
+            sprintf('Failed asserting that no row in the table %s matches the given data.', $table),
+        );
+
+        return $this;
+    }
+
+    public function assertTableHasCount(string $table, int $count): self
+    {
+        Assert::same(
+            query($table)->count()->execute(),
+            $count,
+            sprintf('Failed asserting that the table %s contains %s rows.', $table, $count),
+        );
+
+        return $this;
+    }
+
+    public function assertTableEmpty(string $table): self
+    {
+        return $this->assertTableHasCount($table, count: 0);
+    }
+
+    public function assertTableNotEmpty(string $table): self
+    {
+        return $this->assertTableHasRow($table);
+    }
+
+    private function countMatching(string $table, array $data): int
+    {
+        $select = query($table)->count();
+
+        foreach ($data as $key => $value) {
+            $select->whereField((string) $key, $value);
+        }
+
+        return $select->execute();
+    }
+}

--- a/testo/Support/IntegrationTestCase.php
+++ b/testo/Support/IntegrationTestCase.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Support;
+
+use Tempest\Console\Output\MemoryOutputBuffer;
+use Tempest\Console\Output\StdoutOutputBuffer;
+use Tempest\Console\OutputBuffer;
+use Tempest\Container\GenericContainer;
+use Tempest\Core\FrameworkKernel;
+use Tempest\Database\Connection\Connection;
+use Tempest\Database\Database;
+use Tempest\Database\DatabaseInitializer;
+use Tempest\Discovery\DiscoveryLocation;
+use Tempest\EventBus\EventBus;
+use Tempest\Http\GenericRequest;
+use Tempest\Http\Method;
+use Tempest\Http\Request;
+use Testo\Lifecycle\AfterTest;
+use Testo\Lifecycle\BeforeTest;
+
+use function Tempest\env;
+
+/**
+ * Boots the Tempest framework kernel for Testo test cases.
+ *
+ * Under `tempest/testing` the runner boots the kernel and injects the container into `#[Before]`
+ * hooks. Testo knows nothing about Tempest, so the kernel is booted here instead — once per
+ * process, with the container's singletons and initializers restored after every test.
+ */
+abstract class IntegrationTestCase
+{
+    private static ?FrameworkKernel $kernel = null;
+
+    protected GenericContainer $container;
+
+    protected DatabaseTester $database;
+
+    protected ConsoleTester $console;
+
+    private EventBus $originalEventBus;
+
+    private array $originalSingletons = [];
+
+    private array $originalDynamicInitializers = [];
+
+    #[BeforeTest(priority: 1000)]
+    public function setUpTempest(): void
+    {
+        $root = dirname(__DIR__, 2);
+
+        self::$kernel ??= FrameworkKernel::boot(
+            root: $root,
+            discoveryLocations: [
+                new DiscoveryLocation('Tests\\Testo\\', dirname(__DIR__)),
+            ],
+            internalStorage: $root . '/.tempest/testo_internal_storage/' . env('TEST_TOKEN', 'default'),
+        );
+
+        /** @var GenericContainer $container */
+        $container = self::$kernel->container;
+
+        GenericContainer::setInstance($container);
+
+        $this->container = $container;
+
+        $this->originalSingletons = $container->getSingletons();
+        $this->originalDynamicInitializers = $container->getDynamicInitializers();
+        $this->originalEventBus = $container->get(EventBus::class);
+
+        $this->setUpDatabase()->setUpConsole()->setUpBaseRequest();
+    }
+
+    #[AfterTest(priority: -1000)]
+    public function tearDownTempest(): void
+    {
+        $this->container->setSingletons($this->originalSingletons);
+        $this->container->setDynamicInitializers($this->originalDynamicInitializers);
+
+        // `setSingletons()` only swaps the definitions; the resolved wrapper a test left behind stays
+        // reachable. `singleton()` drops both, so the next test sees the real bus again — without it
+        // the `TestingEventBus` layers would stack and a muted one would keep swallowing events.
+        $this->container->singleton(EventBus::class, $this->originalEventBus);
+    }
+
+    protected function setUpDatabase(): self
+    {
+        $this->container->unregister(Database::class, tagged: true);
+        $this->container->unregister(Connection::class, tagged: true);
+        $this->container->removeInitializer(DatabaseInitializer::class);
+        $this->container->addInitializer(TestingDatabaseInitializer::class);
+
+        $this->database = new DatabaseTester($this->container);
+
+        return $this;
+    }
+
+    protected function setUpConsole(): self
+    {
+        $this->container->singleton(OutputBuffer::class, fn (): MemoryOutputBuffer => new MemoryOutputBuffer());
+        $this->container->singleton(StdoutOutputBuffer::class, fn (): MemoryOutputBuffer => new MemoryOutputBuffer());
+
+        $this->console = new ConsoleTester($this->container);
+
+        return $this;
+    }
+
+    protected function setUpBaseRequest(): self
+    {
+        $request = new GenericRequest(Method::GET, '/', []);
+
+        $this->container->singleton(Request::class, $request);
+        $this->container->singleton(GenericRequest::class, $request);
+
+        return $this;
+    }
+}

--- a/testo/Support/TestingDatabaseInitializer.php
+++ b/testo/Support/TestingDatabaseInitializer.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Testo\Support;
+
+use Tempest\Container\Container;
+use Tempest\Container\DynamicInitializer;
+use Tempest\Container\Singleton;
+use Tempest\Database\Config\DatabaseConfig;
+use Tempest\Database\Connection\Connection;
+use Tempest\Database\Connection\PDOConnection;
+use Tempest\Database\Database;
+use Tempest\Database\GenericDatabase;
+use Tempest\Database\Transactions\GenericTransactionManager;
+use Tempest\EventBus\EventBus;
+use Tempest\Mapper\SerializerFactory;
+use Tempest\Reflection\ClassReflector;
+use UnitEnum;
+
+use function Tempest\Support\str;
+
+/**
+ * Connects to the database configured in `testo/database.testing.config.php` as-is.
+ *
+ * `Tempest\Testing\Testers\Database\TestingDatabaseInitializer` cannot be reused here: it appends
+ * the name of a `Tempest\Testing\Runner\TestRunner` singleton to the database name, to keep the
+ * parallel workers of the Tempest runner apart. Testo has no such runner, so the lookup fails.
+ */
+final class TestingDatabaseInitializer implements DynamicInitializer
+{
+    /** @var array<string, Connection> */
+    private static array $connections = [];
+
+    public function canInitialize(ClassReflector $class, string|UnitEnum|null $tag): bool
+    {
+        return $class->getType()->matches(Database::class);
+    }
+
+    #[Singleton]
+    public function initialize(ClassReflector $class, string|UnitEnum|null $tag, Container $container): Database
+    {
+        $key = str($tag)->toString();
+
+        $connection = self::$connections[$key] ?? null;
+
+        if ($connection === null) {
+            $connection = new PDOConnection($container->get(DatabaseConfig::class, $tag));
+            $connection->connect();
+
+            self::$connections[$key] = $connection;
+        } elseif ($connection->ping() === false) {
+            $connection->reconnect();
+        }
+
+        $container->singleton(Connection::class, $connection, $tag);
+
+        return new GenericDatabase(
+            connection: $connection,
+            transactionManager: new GenericTransactionManager($connection),
+            serializerFactory: $container->get(SerializerFactory::class),
+            eventBus: $container->get(EventBus::class),
+        );
+    }
+}

--- a/testo/database.testing.config.php
+++ b/testo/database.testing.config.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Tempest\Database\Config\MysqlConfig;
+
+use function Tempest\env;
+
+return new MysqlConfig(
+    host: env('TEST_DATABASE_HOST', default: 'localhost'),
+    port: env('TEST_DATABASE_PORT', default: '3306'),
+    username: env('TEST_DATABASE_USERNAME', default: 'root'),
+    password: env('TEST_DATABASE_PASSWORD', default: ''),
+    database: env('TEST_DATABASE_DATABASE', default: 'stitcher-testing'),
+);

--- a/testo/redis.testing.config.php
+++ b/testo/redis.testing.config.php
@@ -1,0 +1,10 @@
+<?php
+
+use Tempest\KeyValue\Redis\Config\RedisConfig;
+
+use function Tempest\env;
+
+return new RedisConfig(
+    host: env('TEST_REDIS_HOST', default: '127.0.0.1'),
+    port: (int) env('TEST_REDIS_PORT', default: 6379),
+);

--- a/tests/database.testing.config.php
+++ b/tests/database.testing.config.php
@@ -2,6 +2,12 @@
 
 use Tempest\Database\Config\MysqlConfig;
 
+use function Tempest\env;
+
 return new MysqlConfig(
-    database: 'stitcher-testing',
+    host: env('TEST_DATABASE_HOST', default: 'localhost'),
+    port: env('TEST_DATABASE_PORT', default: '3306'),
+    username: env('TEST_DATABASE_USERNAME', default: 'root'),
+    password: env('TEST_DATABASE_PASSWORD', default: ''),
+    database: env('TEST_DATABASE_DATABASE', default: 'stitcher-testing'),
 );

--- a/tests/redis.testing.config.php
+++ b/tests/redis.testing.config.php
@@ -1,0 +1,10 @@
+<?php
+
+use Tempest\KeyValue\Redis\Config\RedisConfig;
+
+use function Tempest\env;
+
+return new RedisConfig(
+    host: env('TEST_REDIS_HOST', default: '127.0.0.1'),
+    port: (int) env('TEST_REDIS_PORT', default: 6379),
+);


### PR DESCRIPTION
Companion PR to the benchmark write-up ["What's faster?"](https://php-testo.github.io/blog/what-is-faster) — it puts the three runners side by side in this repo so the numbers can be reproduced.

The Tempest suite in `tests/` is left untouched. Two more suites run the same tests through a different runner:

| Folder     | Runner            | Namespace        | Command            |
|------------|-------------------|------------------|--------------------|
| `tests/`   | `tempest/testing` | `Tests\`         | `composer test`    |
| `phpunit/` | PHPUnit 13        | `Tests\PHPUnit\` | `composer phpunit` |
| `testo/`   | Testo             | `Tests\Testo\`   | `composer testo`   |

## Running

```bash
composer install
cp .env.example .env   # fill in DB / Redis credentials

composer test          # tempest test  -> tests/
composer phpunit       # phpunit       -> phpunit/
composer testo         # testo run     -> testo/
```
