### PR TITLE
Fix typos and formatting in PHP 8.6 documentation

### DIFF
--- a/app/Blog/Content/2026-07-29-new-in-php-86.md
+++ b/app/Blog/Content/2026-07-29-new-in-php-86.md
@@ -84,7 +84,7 @@ final class CreateBooksTable implements MigratesUp
 
 ## [Polling API](*https://wiki.php.net/rfc/poll_api) ## polling-api
 
-The new Polling API was created first and foremost to facilitate easier internal development. Features like PHP-FPM and singal-handling in ZTS (Zend Thread Safety) mode will benefit from a unified platform to build upon. However, the new polling API is also exposed to userland, which could lead to lower-level frameworks like ReactPHP or Amp to make use of them:
+The new Polling API was created first and foremost to facilitate easier internal development. Features like PHP-FPM and signal-handling in ZTS (Zend Thread Safety) mode will benefit from a unified platform to build upon. However, the new polling API is also exposed to userland, which could lead to lower-level frameworks like ReactPHP or Amp to make use of them:
 
 ```php
 use Io\Poll\Context;
@@ -113,7 +113,7 @@ while (true) {
 }
 ```
 
-It's imortant to note that this new polling API won't introduce any new async features to PHP. It's another (and easier) way to interact with async features — previously PHP only had `{php}stream_select()` as an option for I/O multiplexing. Because the new API also works with several backends when available like epoll or WSAPoll, performance will be better compared to `{php}stream_select()` at a certain scale.
+It's important to note that this new polling API won't introduce any new async features to PHP. It's another (and easier) way to interact with async features — previously PHP only had `{php}stream_select()` as an option for I/O multiplexing. Because the new API also works with several backends when available like epoll or WSAPoll, performance will be better compared to `{php}stream_select()` at a certain scale.
 
 The new polling API also doesn't come with a built-in event loop, so wrapping it into a higher-level abstraction is still up to userland libraries.
 
@@ -172,7 +172,7 @@ $delay = $baseDelay->multiplyBy(2 ** $attempt);
 You can also compare two durations directly:
 
 ```php
-if ($durationA < $duractionB) {
+if ($durationA < $durationB) {
     /* … */
 }
 ```
@@ -268,7 +268,7 @@ While this feature will likely be most useful for static analyzers, you can of c
 ```php
 $reflection = /* … a method or function reflector */
 
-$parameters = $reflection->getParameters;
+$parameters = $reflection->getParameters();
 
 $parameters[0]->getDocComment();
 ```
@@ -410,7 +410,7 @@ const {:hl-dep:_:} = 1;
 
 #### Passing objects which are interpreted as arrays
 
-Some functions like `{php}array_walk()` or `{php}inflate_init()` accept objects alongside arrays. The internal way this is implemented can cause subtle bugs and lead to corrupted memory. That's why the behviour is deprecated in PHP 8.6:
+Some functions like `{php}array_walk()` or `{php}inflate_init()` accept objects alongside arrays. The internal way this is implemented can cause subtle bugs and lead to corrupted memory. That's why the behaviour is deprecated in PHP 8.6:
 
 ```php
 $objectInsteadOfArray = new /* … */;
@@ -508,7 +508,7 @@ class Original
 $property = new ReflectionProperty(Original::class, 'property');
 ```
 
-Note that `$property` refers to `{php}Original::$property`. However, you could use that same relfection property to set values on other objects:
+Note that `$property` refers to `{php}Original::$property`. However, you could use that same reflection property to set values on other objects:
 
 ```php
 class Other {}
@@ -577,7 +577,7 @@ new ReflectionExtension('spl')->getClassNames();
 
 #### Deprecate `spl_object_hash`
 
-Instead of `spl_object_hash()`, you should usen `spl_object_id()`.
+Instead of `spl_object_hash()`, you should use `spl_object_id()`.
 
 ```php
 {:hl-dep:spl_object_hash($object):};


### PR DESCRIPTION
Corrected typos and formatting issues in the documentation for the new Polling API and other features in PHP 8.6.

My OCD could not bear the typos in and decided to do a public good 😀 

Greetings and gratefulness from 🇷🇴 . thanks for all your hard work