### PR TITLE
returning VALUES from constructors is deprecated

### DIFF
--- a/app/Blog/Content/2026-07-29-new-in-php-86.md
+++ b/app/Blog/Content/2026-07-29-new-in-php-86.md
@@ -636,7 +636,7 @@ From the RFC:
 > <br><br>
 > The methods which are required for the behaviour to be well-defined are `create_sid()` and `validateId()`.
 
-#### Deprecate returning from constructors and destructors
+#### Deprecate returning values from constructors and destructors
 
 While this used to be technically allowed, a return statement from a constructor or destructor never made any sense, since both functions can only be called in contexts where you couldn't store that return value anyway. That's why the behaviour is now deprecated:
 


### PR DESCRIPTION
early returns are not deprecated, e.g 
`class C{function __construct(){if(rand(0,1)){return;}}}`