### PR TITLE
Fix typos in apathy blog post

### DIFF
--- a/app/Blog/Content/2026-08-21-a-for-apathy.md
+++ b/app/Blog/Content/2026-08-21-a-for-apathy.md
@@ -8,8 +8,8 @@ A while ago I wrote about how the ["A" in "AI" stands for "Artificial"](/blog/a-
 
 My manager told me to "find at least _one_ thing that gives me joy". She had the rare quality of understanding that a happy employee is the key to everything else. Unfortunately, I've also had first-hand experience with the opposite side of management, and know that her mindset was probably the exception to the rule. 
 
-What worries me are developers are completely loosing their joy in coding these days. More and more develop an apathy towards their craft. AI-driven development has shaken so many talented people, to the point where I'm worried about the long-term effects on our trade in the coming years.
+What worries me are developers are completely losing their joy in coding these days. More and more develop an apathy towards their craft. AI-driven development has shaken so many talented people, to the point where I'm worried about the long-term effects on our trade in the coming years.
 
-To managers and decision makers, I urge you: don't loose track of the big picture. Developer happiness pays in the long run; think about more than just the next quarter.
+To managers and decision makers, I urge you: don't lose track of the big picture. Developer happiness pays in the long run; think about more than just the next quarter.
 
 To all those talented programmers out there who've lost joy in their craft and experience that apathy first-hand: find at least _one_ thing that gives you joy. Maybe that _one_ thing is even outside of programming, maybe even completely away from a computer. Life is about more than being an LLM code reviewer, don't forget that.


### PR DESCRIPTION
I think 'loosing' should be spelled as 'losing'. Just like 'Roose' should be spelled 'Rose'. Just kidding. Very relatable article, by the way.